### PR TITLE
Add help and automate command list setting

### DIFF
--- a/api/animals.py
+++ b/api/animals.py
@@ -2,7 +2,7 @@ from requests import get
 
 
 def shiba(update, context):
-    """ Command to return a random Shiba Inu image"""
+    """Get a random Shiba Inu image"""
 
     response = get('http://shibe.online/api/shibes?count=1&urls=true&httpsUrls=false')
     response = response.json()
@@ -14,7 +14,7 @@ def shiba(update, context):
 
 
 def fox(update, context):
-    """ Command to return a random Fox image"""
+    """Get a random Fox image"""
 
     response = get('https://randomfox.ca/floof/')
     response = response.json()
@@ -26,7 +26,7 @@ def fox(update, context):
 
 
 def cat(update, context):
-    """ Command to return a random Cat image"""
+    """Get a random Cat image"""
 
     response = get('https://api.thecatapi.com/v1/images/search')
     response = response.json()
@@ -38,7 +38,7 @@ def cat(update, context):
 
 
 def catfact(update, context):
-    """ Command to return a random Cat Fact"""
+    """Get a random Cat Fact"""
 
     response = get('https://cat-fact.herokuapp.com/facts/random')
     response = response.json()

--- a/api/calc.py
+++ b/api/calc.py
@@ -3,7 +3,7 @@ from configuration import config
 
 
 def calc(update, context):
-    """Command to calculate anything using wolframalpha."""
+    """Calculate anything using wolframalpha"""
     message = update.message
     query = ' '.join(context.args)
 

--- a/api/countdown.py
+++ b/api/countdown.py
@@ -3,7 +3,7 @@ import dateparser
 
 
 def countdown(update, context):
-    """Command to show days left till a date."""
+    """Show days left till a date"""
     message = update.message
     countdown_to = ' '.join(context.args)
 

--- a/api/currency.py
+++ b/api/currency.py
@@ -3,6 +3,7 @@ from babel import numbers
 
 
 def currency(update, context):
+    """Convert currencies"""
     message = update.message
 
     if not context.args:

--- a/api/goodreads.py
+++ b/api/goodreads.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 
 
 def goodreads(update, context):
-    """ Command to query GoodReads for a book"""
+    """Query GoodReads for a book"""
     message = update.message
     query = ' '.join(context.args)
     parse_mode = 'Markdown'
@@ -31,7 +31,7 @@ def goodreads(update, context):
 
 
 def make_result(goodreads_id):
-    """ Search using Goodreads ID of item """
+    """Search using Goodreads ID of item"""
     r = get(f'https://www.goodreads.com/book/show.xml?key={config["GOODREADS_API_KEY"]}&id={goodreads_id}')
     root = ET.fromstring(r.content)
 

--- a/api/hltb.py
+++ b/api/hltb.py
@@ -2,7 +2,7 @@ from howlongtobeatpy import HowLongToBeat
 
 
 def hltb(update, context):
-    """Command to find how long a game takes to beat."""
+    """Find how long a game takes to beat"""
     message = update.message
     game = ' '.join(context.args)
 

--- a/api/insult.py
+++ b/api/insult.py
@@ -2,7 +2,7 @@ from requests import get
 
 
 def insult(update, context):
-    """ Command to return a random insult"""
+    """Get a random insult"""
 
     response = get('https://evilinsult.com/generate_insult.php?lang=en&type=json')
     response = response.json()

--- a/api/jogi.py
+++ b/api/jogi.py
@@ -2,6 +2,7 @@ from configuration import config
 
 
 def jogi(update, context):
+    """Post jogi"""
     message = update.message
     data = context.bot_data
 

--- a/api/joke.py
+++ b/api/joke.py
@@ -4,7 +4,7 @@ import random
 
 
 def joke(update, context):
-    """ Command to return a random joke"""
+    """Get a random joke"""
 
     # Randomly choose between these two APIs
     if random.random() < 0.5:

--- a/api/pfp.py
+++ b/api/pfp.py
@@ -4,7 +4,7 @@ from PIL.ImageColor import colormap
 
 
 def pad_image(update, context):
-    """Pad images to 1:1 for use in profile pictures."""
+    """Pad images to 1:1 for use in profile pictures"""
 
     message = update.message
 

--- a/api/qr.py
+++ b/api/qr.py
@@ -2,7 +2,7 @@ from urllib.parse import urlencode
 
 
 def make(update, context):
-    """ Command to generate QR code from given data"""
+    """Generate QR code from given data"""
     message = update.message
     data = ' '.join(context.args)
 

--- a/api/response.py
+++ b/api/response.py
@@ -2,18 +2,22 @@ from requests import get
 
 
 def wink(update, context):
+    """Reply with a wink GIF"""
     response(update.message, 'wink')
 
 
 def pat(update, context):
+    """Reply with a pat GIF"""
     response(update.message, 'pat')
 
 
 def hug(update, context):
+    """Reply with a hug GIF"""
     response(update.message, 'hug')
 
 
 def response(message, action):
+    """Query API for appropriate action"""
     response = get(f'https://some-random-api.ml/animu/{action}').json()
 
     try:

--- a/api/stats.py
+++ b/api/stats.py
@@ -52,6 +52,7 @@ def increment(stats_dict, chat_id, user_object):
 
 
 def stats(update, context):
+    """Get daily chat stats"""
     global stats_dict
     msg = update.message
     chat_id = msg.chat_id

--- a/api/time.py
+++ b/api/time.py
@@ -4,7 +4,7 @@ from configuration import config
 
 
 def time(update, context):
-    """Command to tell time at a place."""
+    """Tell time at a place"""
     message = update.message
     place = ' '.join(context.args)
 

--- a/api/translate.py
+++ b/api/translate.py
@@ -2,7 +2,7 @@ from googletrans import Translator
 
 
 def translate(update, context):
-    """Command to translate text in a given language using Google translate."""
+    """Translate text to a given language using Google translate"""
     message = update.message
 
     if not context.args:

--- a/api/tts.py
+++ b/api/tts.py
@@ -2,7 +2,7 @@ from gtts import gTTS
 
 
 def tts(update, context):
-    """Command to convert text to speech in a given language using Google TTS."""
+    """Convert text to speech in a given language using Google TTS"""
     message = update.message
     if not context.args:
         try:

--- a/api/ud.py
+++ b/api/ud.py
@@ -3,7 +3,7 @@ from requests import get
 
 
 def ud(update, context):
-    """Command to query UD for word definition."""
+    """Query Urban Dictionary for word definition"""
     message = update.message
     word = ' '.join(context.args)
 

--- a/api/weather.py
+++ b/api/weather.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 
 def weather(update, context):
+    """Show weather at a location"""
     message = update.message
     query = ' '.join(context.args)
     parse_mode = 'Markdown'

--- a/chat_management/ban.py
+++ b/chat_management/ban.py
@@ -1,5 +1,5 @@
 def ban(update, context):
-    """Command to ban deep from group."""
+    """Ban deep from group"""
     message = update.message
     chat_id = message.chat_id
 

--- a/chat_management/kick.py
+++ b/chat_management/kick.py
@@ -1,5 +1,5 @@
 def kick(update, context):
-    """Command to kick deep from group."""
+    """Kick deep from group"""
     message = update.message
     chat_id = message.chat_id
 

--- a/main.py
+++ b/main.py
@@ -11,40 +11,53 @@ import datetime
 
 
 def start(update, context):
+    """Start bot"""
     context.bot.send_message(
         chat_id=update.effective_chat.id,
         text="Hi."
     )
 
 
+def help_cmd(update, context):
+    """Show list of commands"""
+    cmds = context.bot.commands
+
+    help_text = "*Commands for Super Serious Bot:\n*Send a command with no arguments to get its usage\n\n"
+    help_text += ''.join(sorted(f"/{cmd}: {desc}\n\n" for cmd, desc in cmds))
+
+    update.message.reply_text("Message sent in DM")
+    update.message.from_user.send_message(help_text)
+
+
 commands = {
     # "command": function
     "ban": chat_management.ban,
     "calc": api.calc,
-    "countdown": api.countdown,
+    "cat": api.cat,
+    "catfact": api.catfact,
     "convert": api.currency,
+    "countdown": api.countdown,
+    "fox": api.fox,
+    "gr": api.goodreads,
+    "help": help_cmd,
     "hltb": api.hltb,
+    "hug": api.hug,
+    "insult": api.insult,
+    "jogi": api.jogi,
+    "joke": api.joke,
     "kick": chat_management.kick,
+    "pat": api.pat,
+    "pfp": api.pad_image,
+    "qr": api.make,
+    "shiba": api.shiba,
     "start": start,
+    "stats": api.stats,
     "time": api.time,
     "tl": api.translate,
     "tts": api.tts,
     "ud": api.ud,
-    "stats": api.stats,
-    "gr": api.goodreads,
-    "shiba": api.shiba,
     "weather": api.weather,
-    "fox": api.fox,
-    "cat": api.cat,
-    "catfact": api.catfact,
-    "insult": api.insult,
     "wink": api.wink,
-    "pat": api.pat,
-    "hug": api.hug,
-    "joke": api.joke,
-    "qr": api.make,
-    "jogi": api.jogi,
-    "pfp": api.pad_image,
 }
 
 
@@ -76,6 +89,8 @@ def main():
     j.run_daily(
         api.clear, time=datetime.time(18, 30)
     )
+
+    dispatcher.bot.set_my_commands([(cmd, func.__doc__) for cmd, func in commands.items()])
 
     updater.start_polling(clean=True)
     print("Started bot")

--- a/main.py
+++ b/main.py
@@ -25,7 +25,9 @@ def help_cmd(update, context):
     help_text = "*Commands for Super Serious Bot:\n*Send a command with no arguments to get its usage\n\n"
     help_text += ''.join(sorted(f"/{cmd}: {desc}\n\n" for cmd, desc in cmds))
 
-    update.message.reply_text("Message sent in DM")
+    if not update.effective_chat.type == "private":
+        update.message.reply_text("Message sent in DM")
+
     update.message.from_user.send_message(help_text)
 
 


### PR DESCRIPTION
Help command would just show the list that shows up above the text box when user types `/`
It will be sent to DM to avoid spam. Wont need to set the commands and descriptions from botfather either. All the descriptions are the docstrings of the functions. Commands are set only once when the bot starts.

Commands added after this must have docstrings and be added alphabetically to the `commands` dict in `main.py`