### PR TITLE
Fix Embedez API key validation

### DIFF
--- a/src/commands/dl.py
+++ b/src/commands/dl.py
@@ -135,14 +135,16 @@ class MediaDownloader:
 
     def _validate_api_config(self) -> None:
         """Validate API configuration and log warnings."""
-        if APKG_KEY not in config.get(API_SECTION, {}):
+        section = config.get(API_SECTION, {})
+        if not section.get(APKG_KEY):
             logger.warning(
-                "EMBEDEZ_API_KEY not found in config, some downloads may fail"
+                "EMBEDEZ_API_KEY not found or empty, some downloads may fail"
             )
 
     def _has_api_key(self) -> bool:
-        """Check if API key is available."""
-        return APKG_KEY in config.get(API_SECTION, {})
+        """Check if API key is available and non-empty."""
+        section = config.get(API_SECTION, {})
+        return bool(section.get(APKG_KEY))
 
     async def _handle_api_error(
         self, message: Message, error_msg: str = "Failed to download content"


### PR DESCRIPTION
## Summary
- fix API key detection for Embedez downloader so missing keys don't hit rate limits

## Testing
- `python -m py_compile src/commands/dl.py`

------
https://chatgpt.com/codex/tasks/task_e_68634759b7dc8325950a2890a977589c