### PR TITLE
Fix Embedez fallback logic

### DIFF
--- a/src/commands/dl.py
+++ b/src/commands/dl.py
@@ -121,10 +121,13 @@ class MediaDownloader:
             if hostname == "v.redd.it":
                 if await self._handle_vreddit_direct(url, message):
                     return  # Success, no need for fallback
-                # If direct method failed, fall through to embedez
-
-            if hostname == "v.redd.it" or self._is_supported_domain(hostname):
-                await self._handle_with_embedez(url, message)
+                success = await self._handle_with_embedez(url, message)
+                if not success:
+                    await self._handle_youtube(url, message)
+            elif self._is_supported_domain(hostname):
+                success = await self._handle_with_embedez(url, message)
+                if not success:
+                    await self._handle_youtube(url, message)
             elif "youtu" in hostname:
                 await self._handle_youtube(url, message)
             else:
@@ -135,14 +138,16 @@ class MediaDownloader:
 
     def _validate_api_config(self) -> None:
         """Validate API configuration and log warnings."""
-        if APKG_KEY not in config.get(API_SECTION, {}):
+        section = config.get(API_SECTION, {})
+        if not section.get(APKG_KEY):
             logger.warning(
-                "EMBEDEZ_API_KEY not found in config, some downloads may fail"
+                "EMBEDEZ_API_KEY not found or empty, some downloads may fail"
             )
 
     def _has_api_key(self) -> bool:
-        """Check if API key is available."""
-        return APKG_KEY in config.get(API_SECTION, {})
+        """Check if API key is available and non-empty."""
+        section = config.get(API_SECTION, {})
+        return bool(section.get(APKG_KEY))
 
     async def _handle_api_error(
         self, message: Message, error_msg: str = "Failed to download content"
@@ -151,11 +156,12 @@ class MediaDownloader:
         logger.error(f"API error: {error_msg}")
         await message.reply_text(error_msg)
 
-    async def _handle_with_embedez(self, url: str, message: Message) -> None:
-        """Handle media download using embedez API."""
+    async def _handle_with_embedez(self, url: str, message: Message) -> bool:
+        """Handle media download using embedez API. Returns True if successful."""
         if not self._has_api_key():
             await message.reply_text("API key missing. Contact bot owner.")
-            return
+            return False
+
 
         async with aiohttp.ClientSession() as session:
             try:
@@ -165,11 +171,17 @@ class MediaDownloader:
                 async with session.get(
                     self.EMBEDEZ_API_URL, headers=headers, params=params
                 ) as response:
+                    if response.status == 429:
+                        await self._handle_api_error(
+                            message,
+                            "Embedez API rate limit reached or invalid API key."
+                        )
+                        return False
                     if response.status != 200:
                         await self._handle_api_error(
                             message, f"API returned status {response.status}"
                         )
-                        return
+                        return False
 
                     data = await response.json()
 
@@ -178,17 +190,25 @@ class MediaDownloader:
                         await self._handle_api_error(
                             message, f"Failed to fetch content: {error_msg}"
                         )
-                        return
+                        return False
 
                     # Process and send media
-                    media_list = self._process_embedez_response(data)
+                    media_list = await self._process_embedez_response(data)
                     if media_list:
                         await self.send_media_group(message, media_list)
+                        return True
                     else:
                         await message.reply_text("No media found in the response.")
+                        return False
 
             except aiohttp.ClientError as e:
                 await self._handle_api_error(message, f"Network error: {str(e)}")
+                return False
+            except Exception as e:
+                await self._handle_api_error(message, str(e))
+                return False
+
+        return False
 
     def _extract_media_from_list(self, media_items: List[Dict]) -> List[Media]:
         """Extract media from a list of media items."""
@@ -299,8 +319,8 @@ class MediaDownloader:
 
         return media_list
 
-    async def _handle_youtube(self, url: str, message: Message) -> None:
-        """Handle YouTube video download"""
+    async def _handle_youtube(self, url: str, message: Message) -> bool:
+        """Handle media download using yt-dlp. Returns True if successful."""
         try:
             info = await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.ydl.extract_info(url, download=True)
@@ -309,9 +329,11 @@ class MediaDownloader:
 
             await message.reply_video(video=open(video_path, "rb"))
             os.remove(video_path)
+            return True
         except Exception as e:
             logger.error(f"YouTube download error: {e}")
             await message.reply_text("Failed to download YouTube video.")
+            return False
 
     async def _send_single_media(self, message: Message, media: Media) -> bool:
         """Send a single media item. Returns True if successful."""


### PR DESCRIPTION
## Summary
- add fallbacks from Embedez to yt-dlp
- return boolean success status from Embedez and yt-dlp handlers

## Testing
- `python -m py_compile src/commands/dl.py`


------
https://chatgpt.com/codex/tasks/task_e_68634759b7dc8325950a2890a977589c