### PR TITLE
fix(bot): harden P0 review issues

### DIFF
--- a/src/commands/remind.py
+++ b/src/commands/remind.py
@@ -4,17 +4,18 @@ import re
 
 from telegram import Update
 from telegram.constants import ParseMode
-from telegram.error import ChatMigrated
+from telegram.error import ChatMigrated, TelegramError
 from telegram.ext import ContextTypes
 
 import commands
 import utils
 from config.db import get_db
+from config.logger import logger
 from utils.decorators import command
 from utils.messages import get_message
 
 IST_ALIAS_PATTERN = re.compile(r"\bIST\b", re.IGNORECASE)
-REMINDER_DELIVERY_GRACE_SECONDS = 10 * 60
+REMINDER_BATCH_LIMIT = 50
 
 
 def tg_time(unix_time: int, fallback_text: str, format_string: str | None = None) -> str:
@@ -134,28 +135,29 @@ async def remind(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def worker_reminder(context: ContextTypes.DEFAULT_TYPE):
     now = int(datetime.datetime.now(datetime.UTC).timestamp())
-    stale_before = now - REMINDER_DELIVERY_GRACE_SECONDS
 
     async with get_db() as conn:
-        await conn.execute(
-            """
-            DELETE FROM reminders
-            WHERE target_time < ?;
-            """,
-            (stale_before,),
-        )
         async with conn.execute(
             """
             SELECT id, title, target_time, user_id, chat_id
             FROM reminders
             WHERE target_time <= ?
-            AND target_time >= ?;
+            ORDER BY target_time ASC
+            LIMIT ?;
             """,
-            (now, stale_before),
+            (now, REMINDER_BATCH_LIMIT),
         ) as cursor:
             existing_reminders = await cursor.fetchall()
 
     for reminder in existing_reminders:
+        async with get_db() as conn:
+            claim = await conn.execute(
+                "DELETE FROM reminders WHERE id = ?",
+                (reminder["id"],),
+            )
+            if claim.rowcount == 0:
+                continue
+
         text = (
             f"⏰ <code>{html.escape(reminder['title'])}</code>\n\n"
             f"@{await utils.get_username(reminder['user_id'], context)}"
@@ -165,13 +167,20 @@ async def worker_reminder(context: ContextTypes.DEFAULT_TYPE):
                 reminder["chat_id"], text, parse_mode=ParseMode.HTML
             )
         except ChatMigrated as exc:
-            await context.bot.send_message(
-                exc.new_chat_id, text, parse_mode=ParseMode.HTML
-            )
-            async with get_db() as conn:
-                await conn.execute(
-                    "UPDATE reminders SET chat_id = ? WHERE chat_id = ?",
-                    (exc.new_chat_id, reminder["chat_id"]),
+            try:
+                await context.bot.send_message(
+                    exc.new_chat_id, text, parse_mode=ParseMode.HTML
                 )
-        async with get_db() as conn:
-            await conn.execute("DELETE FROM reminders WHERE id = ?", (reminder["id"],))
+            except TelegramError as send_exc:
+                logger.error(
+                    "Failed to deliver migrated reminder %s: %s",
+                    reminder["id"],
+                    send_exc,
+                )
+        except TelegramError as exc:
+            logger.error(
+                "Failed to deliver reminder %s to chat %s: %s",
+                reminder["id"],
+                reminder["chat_id"],
+                exc,
+            )

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -172,9 +172,16 @@ def command_wrapper(
                 )
         except Exception as exc:
             logger.error(
-                f"Error in /{getattr(fn, '__name__', fn.__class__.__name__)}: {exc!s}"
+                "Error in /%s: %s",
+                getattr(fn, "__name__", fn.__class__.__name__),
+                exc,
             )
             logger.error(traceback.format_exc())
+            try:
+                await message.reply_text("Something went wrong. Please try again.")
+            except Exception:
+                pass
+            raise
 
     return wrapped_command
 

--- a/src/commands/summon.py
+++ b/src/commands/summon.py
@@ -131,12 +131,14 @@ async def summon_keyboard_button(update: Update, context: CallbackContext) -> No
         return
     elif action == "resummon":
         last_tag_time = summon_log.get(group_id)
-        if last_tag_time and (datetime.now() - last_tag_time).seconds < 60:
-            remaining_seconds = 60 - (datetime.now() - last_tag_time).seconds
-            await query.answer(
-                f"You can only resummon once every 60 seconds. Wait {remaining_seconds}s."
-            )
-            return
+        if last_tag_time:
+            elapsed = (datetime.now() - last_tag_time).total_seconds()
+            if elapsed < 60:
+                remaining_seconds = int(60 - elapsed)
+                await query.answer(
+                    f"You can only resummon once every 60 seconds. Wait {remaining_seconds}s."
+                )
+                return
 
         await query.answer("Resummoning...")
         async with get_db() as conn:

--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,13 @@ def main():
             "Job queue not initialized. Install python-telegram-bot[job-queue]."
         )
     job_queue.run_daily(worker_habit_tracker, time=datetime.time(14, 30))
-    job_queue.run_repeating(worker_reminder, interval=60, first=10)
+    job_queue.run_repeating(
+        worker_reminder,
+        interval=60,
+        first=10,
+        name="worker_reminder",
+        job_kwargs={"max_instances": 1, "coalesce": True},
+    )
     job_queue.run_daily(command_limits.reset_command_limits, time=datetime.time(18, 30))
     if config.TELEGRAM.UPDATER == "polling":
         logger.info("Using polling...")
@@ -168,7 +174,8 @@ def main():
     if not webhook_url:
         raise RuntimeError("WEBHOOK_URL must be set when UPDATER is 'webhook'")
     port = int(os.environ.get("PORT", "8443"))
-    logger.info(f"Using webhook URL: {webhook_url} with port {port}")
+    # WEBHOOK_URL embeds the bot token as the path — never log it.
+    logger.info("Using webhook mode on port %s", port)
     application.run_webhook(
         listen="0.0.0.0",
         port=port,

--- a/src/management/chat_memory.py
+++ b/src/management/chat_memory.py
@@ -183,11 +183,20 @@ async def chat_stats_summary(chat_id: int, *, today_only: bool) -> tuple[list, i
     return rows, total_count
 
 
-async def last_seen_by_username(username: str):
+async def last_seen_in_chat(chat_id: int, username: str):
+    """Last message from username in this chat only (no cross-chat links)."""
     async with get_db() as conn:
         async with conn.execute(
-            "SELECT username, last_seen, last_message_link FROM user_stats WHERE LOWER(username) = ?",
-            (username.lower(),),
+            """
+            SELECT us.user_id, us.username, cs.message_id, cs.create_time
+            FROM user_stats us
+            INNER JOIN chat_stats cs
+                ON cs.user_id = us.user_id AND cs.chat_id = ?
+            WHERE LOWER(us.username) = ?
+            ORDER BY cs.id DESC
+            LIMIT 1
+            """,
+            (chat_id, username.lower()),
         ) as cursor:
             return await cursor.fetchone()
 

--- a/src/management/stats.py
+++ b/src/management/stats.py
@@ -10,12 +10,35 @@ from telegram.helpers import mention_html
 import commands
 import utils
 from config.db import get_db
-from management.chat_memory import chat_stats_summary, last_seen_by_username
+from management.chat_memory import chat_stats_summary, last_seen_in_chat
 from utils import readable_time
 from utils.decorators import command
 from utils.messages import get_message
 
 _DOW_NAMES = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+
+
+def _message_link(chat_id: int, message_id: int, chat_username: str | None) -> str | None:
+    if not message_id:
+        return None
+    if chat_username:
+        return f"https://t.me/{chat_username}/{message_id}"
+    chat_id_str = str(chat_id)
+    if chat_id_str.startswith("-100"):
+        return f"https://t.me/c/{chat_id_str[4:]}/{message_id}"
+    return None
+
+
+def _timestamp_from_create_time(create_time: object) -> int:
+    if isinstance(create_time, (int, float)):
+        return int(create_time)
+    if isinstance(create_time, datetime):
+        return int(create_time.timestamp())
+    text = str(create_time)
+    try:
+        return int(text)
+    except ValueError:
+        return int(datetime.fromisoformat(text).timestamp())
 
 
 async def reply_chat_stats(
@@ -61,25 +84,28 @@ async def get_last_seen(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
     username_lower = username_input[1].lower()
 
-    user_stats = await last_seen_by_username(username_lower)
+    user_stats = await last_seen_in_chat(message.chat_id, username_lower)
 
     if not user_stats:
-        await message.reply_text(f"@{username_input[1]} has never been seen.")
+        await message.reply_text(
+            f"@{username_input[1]} has never been seen in this chat."
+        )
         return
 
-    last_seen = user_stats["last_seen"]
-    message_link = user_stats["last_message_link"]
     username_display = user_stats["username"]
+    last_seen_int = _timestamp_from_create_time(user_stats["create_time"])
+    message_link = _message_link(
+        message.chat_id,
+        user_stats["message_id"],
+        message.chat.username,
+    )
+    safe_link = html.escape(message_link, quote=True) if message_link else ""
+    html_message = f'\n\n🔗 <a href="{safe_link}">Link</a>' if safe_link else ""
 
-    try:
-        last_seen_int = int(last_seen)
-    except ValueError:
-        last_seen_int = int(datetime.fromisoformat(last_seen).timestamp())
-
-    # Create a link to the message if available
-    html_message = f"\n\n🔗 <a href='{message_link}'>Link</a>" if message_link else ""
-
-    user_mention_string = mention_html(username_display, username_display)
+    user_mention_string = mention_html(
+        int(user_stats["user_id"]),
+        username_display or username_input[1],
+    )
     await message.reply_text(
         f"Last message from {user_mention_string} was {await readable_time(last_seen_int)} ago.{html_message}",
         disable_web_page_preview=True,

--- a/src/utils/messages.py
+++ b/src/utils/messages.py
@@ -38,14 +38,14 @@ async def reply_markdown_or_plain(
     except Exception:
         pass
 
-    if len(text) <= 4096 or not document_name:
+    if len(text) <= 4096:
         return await message.reply_text(
             text,
             disable_web_page_preview=disable_web_page_preview,
         )
 
     buffer = io.BytesIO(text.encode())
-    buffer.name = document_name
+    buffer.name = document_name or "response.txt"
     return await message.reply_document(buffer)
 
 

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -32,9 +32,11 @@ model_module = importlib.import_module("commands.model")
 song_module = importlib.import_module("commands.song")
 transcribe_module = importlib.import_module("commands.transcribe")
 weather_module = importlib.import_module("commands.weather")
-send_markdown_or_plain = importlib.import_module(
-    "utils.messages"
-).send_markdown_or_plain
+messages_module = importlib.import_module("utils.messages")
+send_markdown_or_plain = messages_module.send_markdown_or_plain
+reply_markdown_or_plain = messages_module.reply_markdown_or_plain
+stats_module = importlib.import_module("management.stats")
+remind_module = importlib.import_module("commands.remind")
 decorators = importlib.import_module("utils.decorators")
 
 USER_REPLY_METHODS = {
@@ -78,12 +80,23 @@ class FakeMessage:
         self.reply_to_message = None
         self.replies: list[str] = []
         self.animations: list[str] = []
+        self.documents: list[dict] = []
 
     async def reply_text(self, text: str, **_kwargs):
         self.replies.append(text)
 
     async def reply_animation(self, animation: str, **_kwargs):
         self.animations.append(animation)
+
+    async def reply_document(self, document, **_kwargs):
+        self.documents.append(
+            {
+                "name": getattr(document, "name", None),
+                "text": document.getvalue().decode()
+                if hasattr(document, "getvalue")
+                else document,
+            }
+        )
 
 
 class FakeResponse:
@@ -395,6 +408,102 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(bot.sent_document["chat_id"], 123)
         self.assertEqual(bot.sent_document["name"], "long.txt")
         self.assertEqual(bot.sent_document["text"], "x" * 5000)
+
+    async def test_reply_markdown_or_plain_defaults_document_for_long_text(self):
+        message = FakeMessage()
+
+        await reply_markdown_or_plain(message, "y" * 5000)
+
+        self.assertEqual(message.replies, [])
+        self.assertEqual(len(message.documents), 1)
+        self.assertEqual(message.documents[0]["name"], "response.txt")
+        self.assertEqual(message.documents[0]["text"], "y" * 5000)
+
+    def test_message_link_scopes_to_supergroup_path(self):
+        self.assertEqual(
+            stats_module._message_link(-1001234567890, 42, None),
+            "https://t.me/c/1234567890/42",
+        )
+        self.assertEqual(
+            stats_module._message_link(-1001, 7, "mygroup"),
+            "https://t.me/mygroup/7",
+        )
+        self.assertIsNone(stats_module._message_link(12345, 1, None))
+
+    async def test_worker_reminder_claims_before_send(self):
+        due = [
+            {
+                "id": 1,
+                "title": "ship it",
+                "target_time": 1,
+                "user_id": 9,
+                "chat_id": -1001,
+            }
+        ]
+        claim = SimpleNamespace(rowcount=1)
+        bot = AsyncMock()
+        context = SimpleNamespace(bot=bot)
+
+        class SelectCursor:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def fetchall(self):
+                return due
+
+        class SelectConn:
+            def __init__(self):
+                self.cursor = SelectCursor()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def execute(self, *_args, **_kwargs):
+                return self.cursor
+
+        class ClaimConn:
+            def __init__(self):
+                self.execute_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def execute(self, *args, **_kwargs):
+                self.execute_args = args
+                return claim
+
+        select_conn = SelectConn()
+        claim_conn = ClaimConn()
+
+        with (
+            patch.object(
+                remind_module,
+                "get_db",
+                side_effect=[select_conn, claim_conn],
+            ),
+            patch.object(
+                remind_module.utils,
+                "get_username",
+                AsyncMock(return_value="tester"),
+            ),
+        ):
+            await remind_module.worker_reminder(context)
+
+        self.assertEqual(
+            claim_conn.execute_args,
+            ("DELETE FROM reminders WHERE id = ?", (1,)),
+        )
+        bot.send_message.assert_awaited_once()
+        self.assertEqual(bot.send_message.await_args.args[0], -1001)
 
     async def test_process_mentions_uses_telegram_entity_parser(self):
         entity = SimpleNamespace(type=MessageEntity.MENTION)


### PR DESCRIPTION
## Summary

Focused P0 fixes from the full codebase review:

- **Webhook logging** — no longer logs `WEBHOOK_URL` (path embeds bot token)
- **Command errors** — user gets a failure reply; exception re-raised so `error_handler` / logging channel still fire
- **Long replies** — `reply_markdown_or_plain` falls back to a document (`response.txt`) instead of `reply_text` past 4096 chars
- **`/seen`** — scoped to current chat via `chat_stats`; valid `mention_html(user_id, name)`; no cross-chat deep links
- **Summon cooldown** — uses `total_seconds()` instead of `.seconds`
- **Reminders** — claim-via-delete before send, batch limit, no silent 10m drop, job `max_instances=1` + coalesce

## Test plan

- [x] `uv run pytest tests/ -q` (34 passed)
- [x] `uv run ruff check` on touched files
- [ ] Manual: webhook startup log has no token path
- [ ] Manual: force a command exception → user reply + logging channel
- [ ] Manual: `/seen @user` only reflects activity in the current chat
- [ ] Manual: resummon after >1 day cooldown still allows summon