### PR TITLE
fix(bot): gate expensive commands and harden P1 abuse paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,25 @@ env:
   IMAGE: ghcr.io/obviyus/superseriousbot
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked --group dev
+      - name: Run tests
+        run: uv run pytest -q
+        env:
+          TELEGRAM_TOKEN: test-token
+          QUOTE_CHANNEL_ID: "1"
+          TURSO_DATABASE_URL: ":memory:"
+          TURSO_AUTH_TOKEN: test-token
+
   build:
+    needs: test
     strategy:
       fail-fast: false
       matrix:

--- a/migrations/20260710000000_user_command_limits_unique.py
+++ b/migrations/20260710000000_user_command_limits_unique.py
@@ -1,0 +1,29 @@
+"""
+Migration Name: user_command_limits_unique
+Migration Version: 20260710000000
+"""
+
+
+def upgrade(connection):
+    connection.execute(
+        """
+        DELETE FROM user_command_limits
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM user_command_limits
+            GROUP BY user_id, command
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS user_command_limits_user_command_unique
+        ON user_command_limits (user_id, command)
+        """
+    )
+
+
+def downgrade(connection):
+    connection.execute(
+        "DROP INDEX IF EXISTS user_command_limits_user_command_unique"
+    )

--- a/src/commands/ask.py
+++ b/src/commands/ask.py
@@ -24,6 +24,7 @@ from commands.ai import (
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.media import get_sticker_image_bytes
 from utils.messages import get_message, reply_markdown_or_plain
@@ -160,6 +161,8 @@ async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "ask",
         allow_private_whitelist=True,
     ):
+        return
+    if not await ensure_quota(message, message.from_user.id, "ask"):
         return
 
     api_key = config.API.OPENROUTER_API_KEY
@@ -326,6 +329,8 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not message or not message.from_user or not update.effective_user:
         return
     if not await ensure_command_available(message, message.from_user.id, "edit"):
+        return
+    if not await ensure_quota(message, message.from_user.id, "edit"):
         return
 
     reply = message.reply_to_message

--- a/src/commands/cron.py
+++ b/src/commands/cron.py
@@ -18,6 +18,7 @@ from commands.cron_service import (
     validate_cron_expression,
 )
 from commands.runtime import ensure_command_available
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message
 
@@ -122,6 +123,8 @@ async def cron(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except ValueError as exc:
             await message.reply_text(str(exc))
             return
+        if not await ensure_quota(message, message.from_user.id, "cron"):
+            return
         task = await load_owned_cron_task(
             task_id,
             message.chat_id,
@@ -135,6 +138,9 @@ async def cron(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             parse_mode=ParseMode.HTML,
         )
         await run_cron_task(context, task_id)
+        return
+
+    if not await ensure_quota(message, message.from_user.id, "cron"):
         return
 
     user_request = " ".join(context.args).strip()

--- a/src/commands/highlight.py
+++ b/src/commands/highlight.py
@@ -6,6 +6,7 @@ from telegram.error import Forbidden
 from telegram.ext import ContextTypes
 
 from config.db import get_db
+from config.logger import logger
 from utils.decorators import command
 from utils.messages import get_message
 
@@ -164,12 +165,10 @@ async def highlight_worker(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     ),
                 )
             except Forbidden:
-                await message.reply_text(
-                    f"<a href='tg://user?id={row['user_id']}'>Your highlight</a> "
-                    f"<code>{html.escape(row['string'])}</code> was triggered, but I can't DM you. "
-                    "Please start a conversation with me first.",
-                    parse_mode=ParseMode.HTML,
-                    reply_markup=InlineKeyboardMarkup(
-                        [[start_dm_button(context.bot.username)]]
-                    ),
+                # Do not leak highlight keywords or owner identity into the group.
+                logger.info(
+                    "Highlight DM forbidden for user %s in chat %s",
+                    row["user_id"],
+                    message.chat_id,
                 )
+

--- a/src/commands/meme.py
+++ b/src/commands/meme.py
@@ -4,6 +4,9 @@ from telegram.ext import ContextTypes
 from utils.decorators import command
 from utils.messages import get_message
 
+MEME_API_URL = "https://meme-api.com/gimme"
+MEME_FETCH_ATTEMPTS = 5
+
 
 @command(
     triggers=["meme"],
@@ -19,13 +22,24 @@ async def meme(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> None:
     import aiohttp
 
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://meme-api.com/gimme") as response:
-                if response.status != 200:
-                    await message.reply_text("Could not fetch a meme right now.")
-                    return
-                data = await response.json()
-        url = data["url"]
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=10)
+        ) as session:
+            url = None
+            for _ in range(MEME_FETCH_ATTEMPTS):
+                async with session.get(MEME_API_URL) as response:
+                    if response.status != 200:
+                        await message.reply_text("Could not fetch a meme right now.")
+                        return
+                    data = await response.json()
+                if data.get("nsfw"):
+                    continue
+                url = data.get("url")
+                if url:
+                    break
+            if not url:
+                await message.reply_text("Could not fetch a SFW meme right now.")
+                return
     except (aiohttp.ClientError, KeyError, TypeError):
         await message.reply_text("Could not fetch a meme right now.")
         return

--- a/src/commands/search.py
+++ b/src/commands/search.py
@@ -7,6 +7,7 @@ from telegram import Update
 from telegram.constants import ChatType
 from telegram.ext import ContextTypes
 
+from commands.runtime import ensure_command_available
 from management.chat_memory import (
     enable_fts as enable_chat_fts,
 )
@@ -16,6 +17,7 @@ from management.chat_memory import (
     parse_export_file,
 )
 from management.chat_semantic_search import semantic_search_answer
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message, reply_markdown_or_plain
 
@@ -29,7 +31,12 @@ from utils.messages import get_message, reply_markdown_or_plain
 )
 async def search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = get_message(update)
-    if not message:
+    if not message or not message.from_user:
+        return
+
+    if not await ensure_command_available(message, message.from_user.id, "search"):
+        return
+    if not await ensure_quota(message, message.from_user.id, "search"):
         return
 
     if not context.args:
@@ -43,7 +50,13 @@ async def search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         else None
     )
 
-    answer = await semantic_search_answer(message.chat_id, query, author_id)
+    try:
+        answer = await semantic_search_answer(message.chat_id, query, author_id)
+    except Exception:
+        logging.exception("Semantic search failed for chat %s", message.chat_id)
+        await message.reply_text("Search failed. Please try again.")
+        return
+
     if not answer:
         if not await is_fts_enabled(message.chat_id):
             await message.reply_text(

--- a/src/commands/settings.py
+++ b/src/commands/settings.py
@@ -27,6 +27,8 @@ TOGGLES = (
     SettingToggle("ask", "/ask", "command_whitelist", "ask"),
     SettingToggle("edit", "/edit", "command_whitelist", "edit"),
     SettingToggle("tr", "/tr", "command_whitelist", "tr"),
+    SettingToggle("tldr", "/tldr", "command_whitelist", "tldr"),
+    SettingToggle("search", "/search", "command_whitelist", "search"),
     SettingToggle("cron", "/cron", "command_whitelist", "cron"),
     SettingToggle("song", "/song", "command_whitelist", "song"),
 )

--- a/src/commands/song.py
+++ b/src/commands/song.py
@@ -17,6 +17,7 @@ from commands.ai import (
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message
 
@@ -267,6 +268,8 @@ async def song(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if not await ensure_command_available(message, message.from_user.id, "song"):
         return
+    if not await ensure_quota(message, message.from_user.id, "song"):
+        return
 
     user_prompt = " ".join(context.args).strip() if context.args else ""
     if not user_prompt:
@@ -316,6 +319,9 @@ async def song(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await message.reply_media_group(
             song_media_group(song_tracks(music_task), song_plan.title)
         )
-    except RuntimeError as exc:
+    except Exception as exc:
         logger.exception("Song generation failed: %s", exc)
-        await progress.edit_text("Song generation failed. Please try again.")
+        try:
+            await progress.edit_text("Song generation failed. Please try again.")
+        except Exception:
+            await message.reply_text("Song generation failed. Please try again.")

--- a/src/commands/tldr.py
+++ b/src/commands/tldr.py
@@ -8,9 +8,11 @@ from telegram.ext import ContextTypes
 import commands
 import utils
 from commands.ai import first_message_content, openrouter_json, openrouter_payload
+from commands.runtime import ensure_command_available
 from config.db import get_db
 from config.logger import logger
 from config.options import config
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message, reply_markdown_or_plain
 
@@ -88,6 +90,11 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     if not message or not message.from_user:
         return
 
+    if not await ensure_command_available(message, message.from_user.id, "tldr"):
+        return
+    if not await ensure_quota(message, message.from_user.id, "tldr"):
+        return
+
     url = utils.extract_link(message)
 
     if url:
@@ -96,12 +103,13 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         # Check if it's a YouTube URL
         video_id = extract_youtube_video_id(url_str)
         if video_id:
-            async with get_db() as conn:
-                async with conn.execute(
-                    "SELECT summary FROM tldw WHERE video_id = ?;",
-                    (video_id,),
-                ) as cursor:
-                    cached_summary = await cursor.fetchone()
+            try:
+                async with get_db() as conn:
+                    async with conn.execute(
+                        "SELECT summary FROM tldw WHERE video_id = ?;",
+                        (video_id,),
+                    ) as cursor:
+                        cached_summary = await cursor.fetchone()
                 if cached_summary:
                     await reply_markdown_or_plain(message, cached_summary[0])
                     return
@@ -111,11 +119,15 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                 if nano_api_key:
                     headers["x-api-key"] = nano_api_key
 
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=60)
+                ) as session:
                     async with session.post(
                         "https://nano-gpt.com/api/youtube-transcribe",
                         headers=headers,
-                        json={"urls": [f"https://www.youtube.com/watch?v={video_id}"]},
+                        json={
+                            "urls": [f"https://www.youtube.com/watch?v={video_id}"]
+                        },
                     ) as response:
                         if response.status != 200:
                             await message.reply_text(
@@ -135,10 +147,15 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                     context_hint="a YouTube video transcript",
                 )
                 await reply_markdown_or_plain(message, summary)
-                await conn.execute(
-                    "INSERT INTO tldw (video_id, summary, user_id) VALUES (?, ?, ?);",
-                    (video_id, summary, message.from_user.id),
-                )
+                async with get_db() as conn:
+                    await conn.execute(
+                        "INSERT INTO tldw (video_id, summary, user_id) VALUES (?, ?, ?);",
+                        (video_id, summary, message.from_user.id),
+                    )
+                return
+            except Exception as e:
+                logger.error("Error generating YouTube TLDR for %s: %s", video_id, e)
+                await message.reply_text("I couldn't generate a summary for that.")
                 return
 
         try:

--- a/src/commands/transcribe.py
+++ b/src/commands/transcribe.py
@@ -17,6 +17,7 @@ from commands.ai import (
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
+from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message
 
@@ -86,6 +87,8 @@ async def transcribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         return
 
     if not await ensure_command_available(message, message.from_user.id, "tr"):
+        return
+    if not await ensure_quota(message, message.from_user.id, "tr"):
         return
 
     reply = message.reply_to_message

--- a/src/utils/command_limits.py
+++ b/src/utils/command_limits.py
@@ -1,12 +1,22 @@
+from telegram import Message
 from telegram.ext import ContextTypes
 
 from config.db import get_db
+from utils.admin import is_admin
+
+# Daily defaults for expensive / API-backed commands.
+DEFAULT_DAILY_LIMITS: dict[str, int] = {
+    "ask": 40,
+    "edit": 20,
+    "search": 30,
+    "tldr": 30,
+    "song": 8,
+    "cron": 20,
+    "tr": 40,
+}
 
 
 async def reset_command_limits(_: ContextTypes.DEFAULT_TYPE) -> None:
-    """
-    Reset command limits for all users.
-    """
     async with get_db() as conn:
         await conn.execute(
             """
@@ -14,3 +24,55 @@ async def reset_command_limits(_: ContextTypes.DEFAULT_TYPE) -> None:
             """
         )
 
+
+async def consume_command_quota(user_id: int, command: str) -> bool:
+    """Increment usage for a limited command. Returns False if over daily limit."""
+    default_limit = DEFAULT_DAILY_LIMITS.get(command)
+    if default_limit is None or is_admin(user_id):
+        return True
+
+    async with get_db() as conn:
+        async with conn.execute(
+            """
+            SELECT id, `limit`, current_usage
+            FROM user_command_limits
+            WHERE user_id = ? AND command = ?
+            ORDER BY id
+            LIMIT 1
+            """,
+            (user_id, command),
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        if row is None:
+            await conn.execute(
+                """
+                INSERT INTO user_command_limits (user_id, command, `limit`, current_usage)
+                VALUES (?, ?, ?, 1)
+                """,
+                (user_id, command, default_limit),
+            )
+            return True
+
+        limit = int(row["limit"]) if row["limit"] else default_limit
+        if int(row["current_usage"]) >= limit:
+            return False
+
+        claim = await conn.execute(
+            """
+            UPDATE user_command_limits
+            SET current_usage = current_usage + 1
+            WHERE id = ? AND current_usage < ?
+            """,
+            (row["id"], limit),
+        )
+        return claim.rowcount > 0
+
+
+async def ensure_quota(message: Message, user_id: int, command: str) -> bool:
+    if await consume_command_quota(user_id, command):
+        return True
+    await message.reply_text(
+        "Daily limit for this command reached. Try again tomorrow."
+    )
+    return False

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -80,6 +80,7 @@ class FakeMessage:
         self.reply_to_message = None
         self.replies: list[str] = []
         self.animations: list[str] = []
+        self.photos: list[str] = []
         self.documents: list[dict] = []
 
     async def reply_text(self, text: str, **_kwargs):
@@ -87,6 +88,9 @@ class FakeMessage:
 
     async def reply_animation(self, animation: str, **_kwargs):
         self.animations.append(animation)
+
+    async def reply_photo(self, photo: str, **_kwargs):
+        self.photos.append(photo)
 
     async def reply_document(self, document, **_kwargs):
         self.documents.append(
@@ -139,7 +143,9 @@ class FakeSession:
         return None
 
     def get(self, *_args, **_kwargs):
-        return self.responses.pop(0)
+        if len(self.responses) > 1:
+            return self.responses.pop(0)
+        return self.responses[0]
 
 
 class FailingSession:
@@ -255,6 +261,7 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
                 "ensure_command_available",
                 AsyncMock(return_value=True),
             ),
+            patch.object(ask_module, "ensure_quota", AsyncMock(return_value=True)),
         ):
             await ask_module.ask(update, context)
 
@@ -273,6 +280,7 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
                 "ensure_command_available",
                 AsyncMock(return_value=True),
             ),
+            patch.object(song_module, "ensure_quota", AsyncMock(return_value=True)),
         ):
             await song_module.song(update, context)
 
@@ -295,6 +303,9 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
                 transcribe_module,
                 "ensure_command_available",
                 AsyncMock(return_value=True),
+            ),
+            patch.object(
+                transcribe_module, "ensure_quota", AsyncMock(return_value=True)
             ),
         ):
             await transcribe_module.transcribe(update, context)
@@ -375,7 +386,24 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
         ):
             await meme_module.meme(SimpleNamespace(), SimpleNamespace())
 
-        self.assertEqual(message.replies, ["Could not fetch a meme right now."])
+        self.assertEqual(message.replies, ["Could not fetch a SFW meme right now."])
+
+    async def test_meme_skips_nsfw_responses(self):
+        message = FakeMessage()
+        nsfw = FakeResponse({"url": "https://example.com/nsfw.jpg", "nsfw": True})
+        sfw = FakeResponse({"url": "https://example.com/sfw.jpg", "nsfw": False})
+
+        with (
+            patch.object(meme_module, "get_message", return_value=message),
+            patch(
+                "aiohttp.ClientSession",
+                return_value=FakeSession(nsfw, sfw),
+            ),
+        ):
+            await meme_module.meme(SimpleNamespace(), SimpleNamespace())
+
+        self.assertEqual(message.replies, [])
+        self.assertEqual(message.photos, ["https://example.com/sfw.jpg"])
 
     async def test_weather_handles_malformed_api_data(self):
         message = FakeMessage()


### PR DESCRIPTION
## Summary

P1 from the codebase review:

- **Whitelist** `/search` and `/tldr` (settings toggles + `ensure_command_available`)
- **Daily quotas** for ask/edit/search/tldr/song/cron/tr via `user_command_limits` (admins exempt; daily reset job already exists)
- Unique index migration on `(user_id, command)` for limits rows
- **Song** catches all failures and updates progress message
- **Search** try/except with user-facing error
- **TLDR** whitelist/quota; YouTube path no longer holds DB across network I/O
- **Highlight** Forbidden: log only (no group keyword leak)
- **Meme** skips NSFW (retry up to 5)
- **CI**: `test` job must pass before Docker image build/push

## Test plan

- [x] `uv run pytest -q` (35 passed)
- [x] ruff on changed Python
- [ ] Deploy migrations: `20260710000000_user_command_limits_unique`
- [ ] Whitelist a chat for `/search` and `/tldr` via `/settings` or `/whitelist`
- [ ] Confirm non-whitelisted chat is denied
- [ ] Confirm over-quota reply after burning default daily limit
- [ ] Confirm `/meme` does not post NSFW