### PR TITLE
fix(search): avoid remote vector scans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ FROM python:3.13-slim AS runtime
 
 RUN groupadd --system app \
     && useradd --system --home /app --gid app app \
+    && install -d -o app -g app /app/db \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     # image: ghcr.io/obviyus/superseriousbot:latest
     build: .
     volumes:
-      - ./db/:/db/
+      - ./db/:/app/db/
       - ./src:/app/src
       - ./vis/:/app/vis/
     env_file:

--- a/src/chat_search_config.py
+++ b/src/chat_search_config.py
@@ -4,6 +4,7 @@ ANSWER_MODEL = "x-ai/grok-4.3"
 WINDOW_MESSAGE_COUNT = 24
 WINDOW_STRIDE = 8
 VECTOR_RESULT_COUNT = 12
+AUTHOR_VECTOR_RESULT_COUNT = 512
 ANSWER_EVIDENCE_COUNT = 6
 QUERY_INSTRUCTION = (
     "Instruct: Retrieve Telegram chat windows containing direct or indirect "

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ from config.db import (
 )
 from config.logger import logger
 from config.options import config
+from management.chat_search_cache import sync_search_cache
 from management.chat_search_index import index_pending_windows, searchable_chat_ids
 from management.message_tracking import mention_handler, message_stats_handler
 from utils import command_limits
@@ -44,6 +45,7 @@ async def post_init(application: Application) -> None:
     """
     global bot_startup_time
     await init_db()
+    await sync_search_cache()
     logger.info(f"Started @{application.bot.username} (ID: {application.bot.id})")
 
     bot_startup_time = datetime.datetime.now().timestamp()

--- a/src/management/chat_search_cache.py
+++ b/src/management/chat_search_cache.py
@@ -1,0 +1,204 @@
+import asyncio
+import importlib
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from config.db import TursoRow, get_db
+from config.logger import logger
+
+SEARCH_CACHE_BATCH_SIZE = 1024
+SEARCH_CACHE_PATH = "db/chat-search.db"
+
+_sync_lock = asyncio.Lock()
+
+
+def cache_path() -> Path:
+    return Path(os.environ.get("SEARCH_CACHE_PATH", SEARCH_CACHE_PATH))
+
+
+def open_search_cache():
+    path = cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    libsql_connect: Any = vars(importlib.import_module("libsql"))["connect"]
+    return libsql_connect(
+        str(path),
+        autocommit=True,
+        _check_same_thread=False,
+    )
+
+
+def initialize_search_cache_file() -> None:
+    connection = open_search_cache()
+    try:
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = NORMAL")
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS search_windows (
+                remote_id INTEGER NOT NULL UNIQUE,
+                chat_id INTEGER NOT NULL,
+                start_message_id INTEGER NOT NULL,
+                end_message_id INTEGER NOT NULL,
+                embedding F32_BLOB(1024) NOT NULL,
+                embedding_model TEXT NOT NULL,
+                embedding_dimension INTEGER NOT NULL,
+                UNIQUE (
+                    chat_id,
+                    start_message_id,
+                    end_message_id,
+                    embedding_model,
+                    embedding_dimension
+                )
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS search_windows_chat_idx
+            ON search_windows (chat_id, embedding_model, embedding_dimension)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS search_cache_state (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                remote_id INTEGER NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO search_cache_state (singleton, remote_id)
+            VALUES (1, 0)
+            """
+        )
+    finally:
+        connection.close()
+
+
+def cached_remote_id() -> int:
+    connection = open_search_cache()
+    try:
+        row = connection.execute(
+            "SELECT remote_id FROM search_cache_state WHERE singleton = 1"
+        ).fetchone()
+        return row[0]
+    finally:
+        connection.close()
+
+
+def reset_search_cache() -> None:
+    initialize_search_cache_file()
+    connection = open_search_cache()
+    try:
+        connection.execute("BEGIN")
+        connection.execute("DELETE FROM search_windows")
+        connection.execute(
+            "UPDATE search_cache_state SET remote_id = 0 WHERE singleton = 1"
+        )
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+
+def store_search_cache_rows(rows: Sequence[TursoRow]) -> None:
+    connection = open_search_cache()
+    try:
+        connection.execute("BEGIN")
+        connection.executemany(
+            """
+            INSERT INTO search_windows (
+                remote_id,
+                chat_id,
+                start_message_id,
+                end_message_id,
+                embedding,
+                embedding_model,
+                embedding_dimension
+            )
+            VALUES (?, ?, ?, ?, vector32(?), ?, ?)
+            ON CONFLICT (
+                chat_id,
+                start_message_id,
+                end_message_id,
+                embedding_model,
+                embedding_dimension
+            )
+            DO UPDATE SET
+                remote_id = excluded.remote_id,
+                embedding = excluded.embedding
+            """,
+            [
+                (
+                    row["id"],
+                    row["chat_id"],
+                    row["start_message_id"],
+                    row["end_message_id"],
+                    row["embedding"],
+                    row["embedding_model"],
+                    row["embedding_dimension"],
+                )
+                for row in rows
+            ],
+        )
+        connection.execute(
+            """
+            DELETE FROM search_windows AS old
+            WHERE EXISTS (
+                SELECT 1
+                FROM search_windows AS current
+                WHERE current.chat_id = old.chat_id
+                AND current.start_message_id = old.start_message_id
+                AND current.embedding_model = old.embedding_model
+                AND current.embedding_dimension = old.embedding_dimension
+                AND current.end_message_id > old.end_message_id
+            )
+            """
+        )
+        connection.execute(
+            """
+            UPDATE search_cache_state
+            SET remote_id = ?
+            WHERE singleton = 1
+            """,
+            (rows[-1]["id"],),
+        )
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+
+async def fetch_search_cache_rows(after_remote_id: int) -> list[TursoRow]:
+    async with get_db() as connection:
+        async with connection.execute(
+            """
+            SELECT
+                id,
+                chat_id,
+                start_message_id,
+                end_message_id,
+                vector_extract(embedding) AS embedding,
+                embedding_model,
+                embedding_dimension
+            FROM chat_search_windows
+            WHERE id > ?
+            ORDER BY id
+            LIMIT ?
+            """,
+            (after_remote_id, SEARCH_CACHE_BATCH_SIZE),
+        ) as cursor:
+            return await cursor.fetchall()
+
+
+async def sync_search_cache() -> int:
+    async with _sync_lock:
+        initialize_search_cache_file()
+        synced = 0
+        while rows := await fetch_search_cache_rows(cached_remote_id()):
+            await asyncio.to_thread(store_search_cache_rows, rows)
+            synced += len(rows)
+        if synced:
+            logger.info("Synced %d semantic search windows to local cache", synced)
+        return synced

--- a/src/management/chat_search_index.py
+++ b/src/management/chat_search_index.py
@@ -9,6 +9,7 @@ from chat_search_config import (
     WINDOW_STRIDE,
 )
 from config.db import get_db
+from management.chat_search_cache import reset_search_cache, sync_search_cache
 from openrouter_embeddings import openrouter_embeddings, vector32_json
 
 INDEX_BATCH_WINDOWS = 64
@@ -368,6 +369,7 @@ async def index_pending_windows(
                 chat_id,
                 remaining,
             )
+    await sync_search_cache()
     return indexed
 
 
@@ -389,4 +391,6 @@ async def refresh_windows(api_key: str, chat_ids: list[int]) -> int:
                 if batch_size < INDEX_BATCH_WINDOWS or next_start_message_id is None:
                     break
                 start_message_id = next_start_message_id
+    reset_search_cache()
+    await sync_search_cache()
     return refreshed

--- a/src/management/chat_semantic_search.py
+++ b/src/management/chat_semantic_search.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 import time
@@ -8,6 +9,7 @@ import aiohttp
 from chat_search_config import (
     ANSWER_EVIDENCE_COUNT,
     ANSWER_MODEL,
+    AUTHOR_VECTOR_RESULT_COUNT,
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MODEL,
     QUERY_INSTRUCTION,
@@ -16,6 +18,7 @@ from chat_search_config import (
 from commands.ai import first_message_content
 from config.db import get_db
 from config.options import config
+from management.chat_search_cache import open_search_cache
 from openrouter_embeddings import (
     openrouter_api_headers,
     openrouter_embeddings,
@@ -38,6 +41,12 @@ class SearchEvidence:
         return self.end_message_id
 
 
+@dataclass(frozen=True)
+class SearchCandidate:
+    remote_id: int
+    score: float
+
+
 def telegram_message_link(chat_id: int, message_id: int) -> str | None:
     chat_id_text = str(chat_id)
     if chat_id_text.startswith("-100"):
@@ -56,56 +65,96 @@ async def embed_search_query(session: aiohttp.ClientSession, query: str) -> str:
     return vector32_json(embeddings[0])
 
 
-async def vector_search_windows(
+async def vector_search_candidates(
     chat_id: int,
     query_vector: str,
-    author_id: int | None,
-) -> list[SearchEvidence]:
-    async with get_db() as conn:
-        async with conn.execute(
-            """
+    result_count: int,
+) -> list[SearchCandidate]:
+    def search() -> list[tuple]:
+        connection = open_search_cache()
+        try:
+            return connection.execute(
+                """
             SELECT
-                w.chat_id,
-                w.start_message_id,
-                w.end_message_id,
-                w.message_text,
+                w.remote_id,
                 vector_distance_cos(w.embedding, vector32(?)) AS distance
-            FROM chat_search_windows w
+            FROM search_windows w
             WHERE w.chat_id = ?
             AND w.embedding_model = ?
             AND w.embedding_dimension = ?
-            AND (
-                ? IS NULL
-                OR EXISTS (
-                    SELECT 1
-                    FROM chat_stats cs
-                    WHERE cs.chat_id = w.chat_id
-                    AND cs.message_id BETWEEN w.start_message_id AND w.end_message_id
-                    AND cs.user_id = ?
-                )
-            )
             ORDER BY distance ASC
             LIMIT ?;
             """,
+                (
+                    query_vector,
+                    chat_id,
+                    EMBEDDING_MODEL,
+                    EMBEDDING_DIMENSIONS,
+                    result_count,
+                ),
+            ).fetchall()
+        finally:
+            connection.close()
+
+    rows = await asyncio.to_thread(search)
+
+    return [SearchCandidate(remote_id=row[0], score=1 - row[1]) for row in rows]
+
+
+async def fetch_search_evidence(
+    candidates: list[SearchCandidate],
+    author_id: int | None,
+) -> list[SearchEvidence]:
+    if not candidates:
+        return []
+    values = ", ".join("(?, ?)" for _ in candidates)
+    candidate_params = [
+        value
+        for rank, candidate in enumerate(candidates)
+        for value in (candidate.remote_id, rank)
+    ]
+    async with get_db() as connection:
+        async with connection.execute(
+            f"""
+            WITH candidates(remote_id, rank) AS (VALUES {values})
+            SELECT
+                windows.id,
+                windows.chat_id,
+                windows.start_message_id,
+                windows.end_message_id,
+                windows.message_text
+            FROM candidates
+            JOIN chat_search_windows windows ON windows.id = candidates.remote_id
+            WHERE (
+                ? IS NULL
+                OR EXISTS (
+                    SELECT 1
+                    FROM chat_stats messages
+                    WHERE messages.chat_id = windows.chat_id
+                    AND messages.message_id BETWEEN windows.start_message_id
+                        AND windows.end_message_id
+                    AND messages.user_id = ?
+                )
+            )
+            ORDER BY candidates.rank
+            LIMIT ?
+            """,
             (
-                query_vector,
-                chat_id,
-                EMBEDDING_MODEL,
-                EMBEDDING_DIMENSIONS,
+                *candidate_params,
                 author_id,
                 author_id,
                 VECTOR_RESULT_COUNT,
             ),
         ) as cursor:
             rows = await cursor.fetchall()
-
+    scores = {candidate.remote_id: candidate.score for candidate in candidates}
     return [
         SearchEvidence(
             chat_id=row["chat_id"],
             start_message_id=row["start_message_id"],
             end_message_id=row["end_message_id"],
             text=row["message_text"],
-            score=1 - row["distance"],
+            score=scores[row["id"]],
         )
         for row in rows
     ]
@@ -219,7 +268,18 @@ async def semantic_search_answer(
     async with aiohttp.ClientSession() as session:
         query_vector = await embed_search_query(session, query)
         embedded = time.monotonic()
-        vector_windows = await vector_search_windows(chat_id, query_vector, author_id)
+        candidate_count = (
+            AUTHOR_VECTOR_RESULT_COUNT if author_id is not None else VECTOR_RESULT_COUNT
+        )
+        candidates = await vector_search_candidates(
+            chat_id,
+            query_vector,
+            candidate_count,
+        )
+        vector_windows = await fetch_search_evidence(
+            candidates,
+            author_id,
+        )
         evidence = select_evidence(vector_windows)
         if not evidence:
             return None

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import tempfile
 import unittest
 from unittest.mock import AsyncMock, patch
 
@@ -12,7 +13,10 @@ os.environ.setdefault("TURSO_DATABASE_URL", ":memory:")
 os.environ.setdefault("TURSO_AUTH_TOKEN", "test-token")
 
 semantic_search = importlib.import_module("management.chat_semantic_search")
+search_cache = importlib.import_module("management.chat_search_cache")
 search_index = importlib.import_module("management.chat_search_index")
+db = importlib.import_module("config.db")
+libsql = importlib.import_module("libsql")
 
 
 class SemanticSearchTests(unittest.TestCase):
@@ -109,6 +113,175 @@ class SemanticSearchTests(unittest.TestCase):
         )
 
 
+class SearchCacheTests(unittest.IsolatedAsyncioTestCase):
+    async def test_vector_search_reads_local_cache_and_scopes_chat(self):
+        def vector(first: int) -> str:
+            return f"[{first}," + ",".join(["0"] * 1023) + "]"
+
+        columns = {
+            name: index
+            for index, name in enumerate(
+                (
+                    "id",
+                    "chat_id",
+                    "start_message_id",
+                    "end_message_id",
+                    "embedding",
+                    "embedding_model",
+                    "embedding_dimension",
+                )
+            )
+        }
+        rows = [
+            search_cache.TursoRow(
+                (1, -1001, 1, 24, vector(1), "model", 1024),
+                columns,
+            ),
+            search_cache.TursoRow(
+                (2, -1001, 25, 48, vector(-1), "model", 1024),
+                columns,
+            ),
+            search_cache.TursoRow(
+                (3, -1002, 1, 24, vector(1), "model", 1024),
+                columns,
+            ),
+        ]
+
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.dict(
+                os.environ,
+                {"SEARCH_CACHE_PATH": f"{directory}/search.db"},
+            ),
+        ):
+            search_cache.initialize_search_cache_file()
+            search_cache.store_search_cache_rows(rows)
+            with (
+                patch.object(semantic_search, "EMBEDDING_MODEL", "model"),
+                patch.object(semantic_search, "get_db", side_effect=AssertionError),
+            ):
+                candidates = await semantic_search.vector_search_candidates(
+                    -1001,
+                    vector(1),
+                    12,
+                )
+
+        self.assertEqual([item.remote_id for item in candidates], [1, 2])
+
+    async def test_evidence_fetch_preserves_author_filter(self):
+        class ConnectionContext:
+            def __init__(self, connection):
+                self.connection = connection
+
+            async def __aenter__(self):
+                return self.connection
+
+            async def __aexit__(self, *_args):
+                return None
+
+        with tempfile.TemporaryDirectory() as directory:
+            connection = libsql.connect(
+                f"{directory}/remote.db",
+                autocommit=True,
+                _check_same_thread=False,
+            )
+            connection.execute(
+                """
+                CREATE TABLE chat_search_windows (
+                    id INTEGER PRIMARY KEY,
+                    chat_id INTEGER NOT NULL,
+                    start_message_id INTEGER NOT NULL,
+                    end_message_id INTEGER NOT NULL,
+                    message_text TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE chat_stats (
+                    chat_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    message_id INTEGER NOT NULL
+                )
+                """
+            )
+            connection.executemany(
+                "INSERT INTO chat_search_windows VALUES (?, -1001, ?, ?, ?)",
+                [(1, 1, 24, "first"), (2, 25, 48, "second")],
+            )
+            connection.executemany(
+                "INSERT INTO chat_stats VALUES (-1001, ?, ?)",
+                [(7, 10), (8, 30)],
+            )
+            wrapped = db.TursoConnection(connection)
+            candidates = [
+                semantic_search.SearchCandidate(1, 0.9),
+                semantic_search.SearchCandidate(2, 0.8),
+            ]
+            try:
+                with patch.object(
+                    semantic_search,
+                    "get_db",
+                    return_value=ConnectionContext(wrapped),
+                ):
+                    evidence = await semantic_search.fetch_search_evidence(
+                        candidates,
+                        author_id=7,
+                    )
+            finally:
+                await wrapped.close()
+
+        self.assertEqual(
+            [(item.text, item.score) for item in evidence], [("first", 0.9)]
+        )
+
+    def test_new_tail_window_replaces_stale_cached_range(self):
+        vector = "[1," + ",".join(["0"] * 1023) + "]"
+        columns = {
+            name: index
+            for index, name in enumerate(
+                (
+                    "id",
+                    "chat_id",
+                    "start_message_id",
+                    "end_message_id",
+                    "embedding",
+                    "embedding_model",
+                    "embedding_dimension",
+                )
+            )
+        }
+        rows = [
+            search_cache.TursoRow(
+                (1, -1001, 1, 10, vector, "model", 1024),
+                columns,
+            ),
+            search_cache.TursoRow(
+                (2, -1001, 1, 20, vector, "model", 1024),
+                columns,
+            ),
+        ]
+
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.dict(
+                os.environ,
+                {"SEARCH_CACHE_PATH": f"{directory}/search.db"},
+            ),
+        ):
+            search_cache.initialize_search_cache_file()
+            search_cache.store_search_cache_rows(rows)
+            connection = search_cache.open_search_cache()
+            try:
+                cached = connection.execute(
+                    "SELECT end_message_id, remote_id FROM search_windows"
+                ).fetchall()
+            finally:
+                connection.close()
+
+        self.assertEqual(cached, [(20, 2)])
+
+
 class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
     async def test_pending_indexing_allocates_each_chat_a_share(self):
         class SessionContext:
@@ -132,6 +305,7 @@ class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
                 "index_chat_windows",
                 index_chat_windows,
             ),
+            patch.object(search_index, "sync_search_cache", AsyncMock()),
         ):
             indexed = await search_index.index_pending_windows(
                 "key",
@@ -168,6 +342,8 @@ class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
                 "index_window_batch",
                 index_window_batch,
             ),
+            patch.object(search_index, "reset_search_cache"),
+            patch.object(search_index, "sync_search_cache", AsyncMock()),
         ):
             refreshed = await search_index.refresh_windows("key", [-1001])
 


### PR DESCRIPTION
## What changed

- mirror semantic vectors and range metadata into a persistent local libSQL cache
- rank search candidates locally, then fetch only the bounded evidence rows from Turso
- keep the cache incremental with the existing indexing worker and rebuild it on explicit refreshes
- preserve reply-to-author filtering with a bounded candidate set
- add the writable cache path to the image and development Compose volume

## Root cause

Every search computed cosine distance across every vector for that chat in Turso. Concurrent commands overlapped two remote linear scans; retrieval crossed the transport's 10-second deadline and both commands returned the generic failure message.

## Impact

- normal search: about 36,866 remote vector-row scans becomes 12 primary-key evidence reads
- author-scoped search: bounded at 512 candidates
- Turso writes: unchanged
- initial cache fill: 43,255 reads; subsequent syncs read only newly indexed rows
- local cache: about 195 MB; vectors and range metadata only, no raw message text

Measured against the current production index: local ranking took 63 ms sequentially and 127 ms for two simultaneous searches. Evidence fetch took about 0.64 seconds per search.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q` (76 passed)
- production Docker image build
- non-root persistent-volume write check
- full-size cache build and concurrent retrieval benchmark
