### PR TITLE
fix(search): own citation links

### DIFF
--- a/src/management/chat_semantic_search.py
+++ b/src/management/chat_semantic_search.py
@@ -25,7 +25,7 @@ from openrouter_embeddings import (
     vector32_json,
 )
 
-_CITATION_RE = re.compile(r"\[(\d+)(?::(\d+))?]")
+_CITATION_RE = re.compile(r"(?P<space>[ \t]*)\[(?P<index>\d+)(?::[^]\s]+)?](?!\()")
 
 
 @dataclass(frozen=True)
@@ -192,8 +192,9 @@ def answer_messages(
                 "You are the memory of a playful Telegram group, not a fact-checker or "
                 "auditor. Use only the evidence, but synthesize it freely. Answer first, "
                 "without discussing logs, evidence quality, or your process. Keep it to "
-                "one to three sentences and cite claims with the evidence number and exact "
-                "message ID, such as [1:123456]. Preserve participants' @handles exactly. "
+                "one to three sentences and cite claims only with the evidence number, "
+                "such as [1]. Never put message IDs, ranges, or URLs in citations. "
+                "Preserve participants' @handles exactly. "
                 "For social, subjective, hypothetical, "
                 "'most likely', and similar participant questions, always make the most "
                 "entertaining plausible choice supported by the chat. Weak or indirect "
@@ -245,16 +246,23 @@ async def answer_from_evidence(
 
 
 def link_citations(answer: str, evidence: list[SearchEvidence]) -> str:
+    previous_index: int | None = None
+    previous_end = -1
+
     def replace(match: re.Match[str]) -> str:
-        index = int(match.group(1))
+        nonlocal previous_end, previous_index
+        index = int(match.group("index"))
+        adjacent_duplicate = index == previous_index and match.start() == previous_end
+        previous_index = index
+        previous_end = match.end()
+        if adjacent_duplicate:
+            return ""
         if index < 1 or index > len(evidence):
-            return match.group(0)
+            return ""
         item = evidence[index - 1]
-        message_id = int(match.group(2)) if match.group(2) else item.citation_message_id
-        if not item.start_message_id <= message_id <= item.end_message_id:
-            return match.group(0)
-        link = telegram_message_link(item.chat_id, message_id)
-        return f"[{index}]({link})" if link else match.group(0)
+        link = telegram_message_link(item.chat_id, item.citation_message_id)
+        citation = f"[{index}]({link})" if link else ""
+        return match.group("space") + citation if citation else ""
 
     return _CITATION_RE.sub(replace, answer)
 

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -95,22 +95,28 @@ class SemanticSearchTests(unittest.TestCase):
         self.assertIn("always make", messages[0]["content"])
         self.assertIn("Weak or indirect receipts are enough", messages[0]["content"])
         self.assertIn("Never answer 'I cannot tell'", messages[0]["content"])
+        self.assertIn(
+            "cite claims only with the evidence number", messages[0]["content"]
+        )
+        self.assertIn("Never put message IDs, ranges, or URLs", messages[0]["content"])
 
-    def test_link_citations_links_only_citations_in_answer(self):
+    def test_link_citations_owns_message_ids_and_is_idempotent(self):
         evidence = [
             semantic_search.SearchEvidence(-1001234567890, 1, 24, "first", 0.8),
             semantic_search.SearchEvidence(-1001234567890, 25, 48, "second", 0.7),
         ]
 
         answer = semantic_search.link_citations(
-            "Best guess: @user [2:30]. Unsupported [3:50].",
+            "Best guess: @user [2:30][2:31]. Range [1:1-24]. Unsupported [3:50].",
             evidence,
         )
 
         self.assertEqual(
             answer,
-            "Best guess: @user [2](https://t.me/c/1234567890/30). Unsupported [3:50].",
+            "Best guess: @user [2](https://t.me/c/1234567890/48). "
+            "Range [1](https://t.me/c/1234567890/24). Unsupported.",
         )
+        self.assertEqual(semantic_search.link_citations(answer, evidence), answer)
 
 
 class SearchCacheTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- make the model cite evidence numbers only
- generate Telegram message IDs and URLs deterministically in code
- remove invalid citations and collapse adjacent duplicates
- keep citation linking idempotent

## Root cause

The answer model owned both evidence selection and raw Telegram message IDs. It sometimes invented truncated IDs, ranges, or repeated citation tokens. The linker only transformed valid IDs, so malformed internal citation syntax leaked into Telegram output.

## Impact

Search answers now render stable clickable citations from the selected evidence window. Model-generated message IDs, ranges, and URLs cannot reach users.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q` (76 passed)