### PR TITLE
fix(dl): fall back to yt-dlp for Instagram reels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "python-telegram-bot[job-queue,rate-limiter,webhooks]~=22.8",
   "telegramify-markdown~=1.2.0",
   "libsql>=0.1.11",
+  "yt-dlp~=2026.7.4",
 ]
 
 

--- a/src/commands/dl.py
+++ b/src/commands/dl.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 from urllib.parse import ParseResult, urlparse
@@ -7,6 +8,8 @@ from telegram import InputFile, InputMediaPhoto, InputMediaVideo, Message, Updat
 from telegram.constants import ChatType, ReactionEmoji
 from telegram.error import BadRequest
 from telegram.ext import ContextTypes
+from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
 
 import utils
 from config.db import get_db
@@ -18,6 +21,7 @@ from utils.messages import get_message
 MAX_MEDIA_COUNT = 10
 MAX_DOWNLOAD_SIZE = 47 * (1 << 20)
 DOWNLOAD_CHUNK_SIZE = 256 * 1024
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp", ".gif")
 COBALT_TIMEOUT = aiohttp.ClientTimeout(
     total=45, connect=10, sock_connect=10, sock_read=30
 )
@@ -29,10 +33,6 @@ MEDIA_TIMEOUT = aiohttp.ClientTimeout(
 def _cobalt_endpoint() -> str | None:
     url = config.API.COBALT_URL.strip()
     return f"{url.rstrip('/')}/" if url else None
-
-
-def _target_url(url: ParseResult) -> str:
-    return url.geturl()
 
 
 def _is_instagram_reel(url: ParseResult) -> bool:
@@ -52,6 +52,66 @@ async def _is_auto_dl_enabled(chat_id: int) -> bool:
     ):
         row = await cursor.fetchone()
     return bool(row and row["auto_dl"])
+
+
+async def _request_cobalt(
+    session: aiohttp.ClientSession,
+    endpoint: str,
+    target: str,
+) -> dict:
+    async with session.post(
+        endpoint,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        json={"url": target},
+    ) as resp:
+        try:
+            data = await resp.json()
+        except (aiohttp.ContentTypeError, json.JSONDecodeError):
+            text = await resp.text()
+            raise RuntimeError(
+                f"Cobalt non-JSON response: {resp.status} {text[:120]}"
+            ) from None
+        if resp.status != 200 and data.get("status") != "error":
+            raise RuntimeError(f"Cobalt HTTP {resp.status}: {data}")
+    return data
+
+
+def _needs_yt_dlp(url: ParseResult, data: dict) -> bool:
+    if not _is_instagram_reel(url):
+        return False
+    if data.get("status") == "error":
+        return True
+    filename = data.get("filename")
+    return (
+        data.get("status") in {"redirect", "tunnel"}
+        and isinstance(filename, str)
+        and filename.lower().endswith(IMAGE_EXTENSIONS)
+    )
+
+
+def _extract_with_yt_dlp(target: str) -> tuple[str, str]:
+    with YoutubeDL(
+        {
+            "format": "best[ext=mp4]/best",
+            "noplaylist": True,
+            "quiet": True,
+            "no_warnings": True,
+        }
+    ) as yt_dlp:
+        info = yt_dlp.extract_info(target, download=False)
+    return info["url"], f"instagram_{info['id']}.{info['ext']}"
+
+
+async def _fetch_with_yt_dlp(
+    message: Message,
+    session: aiohttp.ClientSession,
+    target: str,
+) -> None:
+    media_url, filename = await asyncio.to_thread(_extract_with_yt_dlp, target)
+    await _fetch_and_send(message, session, media_url, filename)
 
 
 async def _fetch_and_send(
@@ -91,7 +151,7 @@ async def _fetch_and_send(
         file = InputFile(buffer, filename=safe_name)
         target_name = safe_name.lower()
 
-        if target_name.endswith((".jpg", ".jpeg", ".png", ".webp", ".gif")) or (
+        if target_name.endswith(IMAGE_EXTENSIONS) or (
             content_type and content_type.startswith("image/")
         ):
             await message.reply_photo(photo=file)
@@ -111,7 +171,7 @@ async def _fetch_and_send(
         await message.reply_text("Failed to download media.")
 
 
-async def _download_media(message: Message, target: str) -> None:
+async def _download_media(message: Message, url: ParseResult) -> None:
     endpoint = _cobalt_endpoint()
     if not endpoint:
         logger.error("COBALT_URL is not configured.")
@@ -120,23 +180,22 @@ async def _download_media(message: Message, target: str) -> None:
 
     try:
         async with aiohttp.ClientSession(timeout=COBALT_TIMEOUT) as session:
-            async with session.post(
-                endpoint,
-                headers={
-                    "Accept": "application/json",
-                    "Content-Type": "application/json",
-                },
-                json={"url": target},
-            ) as resp:
-                try:
-                    data = await resp.json()
-                except (aiohttp.ContentTypeError, json.JSONDecodeError):
-                    text = await resp.text()
-                    raise RuntimeError(
-                        f"Cobalt non-JSON response: {resp.status} {text[:120]}"
-                    ) from None
-                if resp.status != 200 and data.get("status") != "error":
-                    raise RuntimeError(f"Cobalt HTTP {resp.status}: {data}")
+            target = url.geturl()
+            try:
+                data = await _request_cobalt(session, endpoint, target)
+            except (aiohttp.ClientError, RuntimeError, TimeoutError) as e:
+                if not _is_instagram_reel(url):
+                    raise
+                logger.warning("Cobalt failed for Instagram Reel; using yt-dlp: %s", e)
+                await _fetch_with_yt_dlp(message, session, target)
+                return
+
+            if _needs_yt_dlp(url, data):
+                logger.info(
+                    "Cobalt could not resolve Instagram Reel video; using yt-dlp."
+                )
+                await _fetch_with_yt_dlp(message, session, target)
+                return
 
             status = data.get("status")
             if status in {"redirect", "tunnel"}:
@@ -199,8 +258,9 @@ async def _download_media(message: Message, target: str) -> None:
         RuntimeError,
         TimeoutError,
         TypeError,
+        DownloadError,
     ) as e:
-        logger.error(f"Cobalt error: {e}")
+        logger.error(f"Media download error: {e}")
         await message.reply_text("Failed to fetch media.")
 
 
@@ -220,7 +280,7 @@ async def dl_command(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         await message.reply_text("Please provide a valid URL.")
         return
 
-    await _download_media(message, _target_url(url))
+    await _download_media(message, url)
 
 
 async def auto_dl_message_handler(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
@@ -241,5 +301,5 @@ async def auto_dl_message_handler(update: Update, _: ContextTypes.DEFAULT_TYPE) 
                 await message.set_reaction(ReactionEmoji.HIGH_VOLTAGE_SIGN)
             except BadRequest as e:
                 logger.debug("Skipping auto-dl reaction: %s", e)
-            await _download_media(message, _target_url(url))
+            await _download_media(message, url)
             return

--- a/tests/test_dl.py
+++ b/tests/test_dl.py
@@ -1,0 +1,107 @@
+import importlib
+import os
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlparse
+
+import aiohttp
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+os.environ.setdefault("QUOTE_CHANNEL_ID", "1")
+os.environ.setdefault("TURSO_DATABASE_URL", ":memory:")
+os.environ.setdefault("TURSO_AUTH_TOKEN", "test-token")
+
+dl = importlib.import_module("commands.dl")
+
+
+class SessionContext:
+    def __init__(self) -> None:
+        self.session = SimpleNamespace()
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class DownloadTests(IsolatedAsyncioTestCase):
+    async def test_instagram_reel_image_falls_back_to_yt_dlp(self) -> None:
+        message = SimpleNamespace(reply_text=AsyncMock())
+        url = urlparse("https://www.instagram.com/reel/DbT2vSHtvXs/")
+        session = SessionContext()
+
+        with (
+            patch.object(dl.config.API, "COBALT_URL", "http://cobalt/"),
+            patch.object(dl.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                dl,
+                "_request_cobalt",
+                AsyncMock(
+                    return_value={
+                        "status": "tunnel",
+                        "url": "http://cobalt/tunnel/photo",
+                        "filename": "instagram_DbT2vSHtvXs.jpg",
+                    }
+                ),
+            ),
+            patch.object(dl, "_fetch_with_yt_dlp", AsyncMock()) as fallback,
+            patch.object(dl, "_fetch_and_send", AsyncMock()) as cobalt_fetch,
+        ):
+            await dl._download_media(message, url)
+
+        fallback.assert_awaited_once_with(message, session.session, url.geturl())
+        cobalt_fetch.assert_not_awaited()
+
+    async def test_instagram_reel_cobalt_video_stays_on_cobalt(self) -> None:
+        message = SimpleNamespace(reply_text=AsyncMock())
+        url = urlparse("https://www.instagram.com/reel/DbT2vSHtvXs/")
+        session = SessionContext()
+        cobalt_url = "https://cdn.example.com/reel.mp4"
+
+        with (
+            patch.object(dl.config.API, "COBALT_URL", "http://cobalt/"),
+            patch.object(dl.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                dl,
+                "_request_cobalt",
+                AsyncMock(
+                    return_value={
+                        "status": "redirect",
+                        "url": cobalt_url,
+                        "filename": "instagram_DbT2vSHtvXs.mp4",
+                    }
+                ),
+            ),
+            patch.object(dl, "_fetch_with_yt_dlp", AsyncMock()) as fallback,
+            patch.object(dl, "_fetch_and_send", AsyncMock()) as cobalt_fetch,
+        ):
+            await dl._download_media(message, url)
+
+        fallback.assert_not_awaited()
+        cobalt_fetch.assert_awaited_once_with(
+            message,
+            session.session,
+            cobalt_url,
+            "instagram_DbT2vSHtvXs.mp4",
+        )
+
+    async def test_instagram_reel_cobalt_failure_falls_back_to_yt_dlp(self) -> None:
+        message = SimpleNamespace(reply_text=AsyncMock())
+        url = urlparse("https://www.instagram.com/reel/DbT2vSHtvXs/")
+        session = SessionContext()
+
+        with (
+            patch.object(dl.config.API, "COBALT_URL", "http://cobalt/"),
+            patch.object(dl.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                dl,
+                "_request_cobalt",
+                AsyncMock(side_effect=aiohttp.ClientConnectionError("offline")),
+            ),
+            patch.object(dl, "_fetch_with_yt_dlp", AsyncMock()) as fallback,
+        ):
+            await dl._download_media(message, url)
+
+        fallback.assert_awaited_once_with(message, session.session, url.geturl())

--- a/uv.lock
+++ b/uv.lock
@@ -1043,6 +1043,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extra = ["job-queue", "rate-limiter", "webhooks"] },
     { name = "telegramify-markdown" },
+    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -1065,6 +1066,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "~=1.2.2" },
     { name = "python-telegram-bot", extras = ["job-queue", "rate-limiter", "webhooks"], specifier = "~=22.8" },
     { name = "telegramify-markdown", specifier = "~=1.2.0" },
+    { name = "yt-dlp", specifier = "~=2026.7.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1283,4 +1285,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
     { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
     { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
 ]


### PR DESCRIPTION
## Summary
- keep Cobalt as the primary `/dl` provider
- use yt-dlp only when an Instagram Reel fails or resolves to an image
- reuse the existing bounded media download/send path

## Proof
- `uv run pytest -q` (86 passed)
- `uv run ruff check .`
- `uv run ty check src`
- built Docker image; exact failing Reel reached `reply_video` as a 7,014,130-byte MP4