### PR TITLE
feat(ai): adopt AI SDK and agentic web search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+  "ai[openai]~=0.4.0",
   "aiohttp~=3.14.3",
   "async-lru~=2.3.0",
   "coloredlogs>=15.0.1",
@@ -12,10 +13,10 @@ dependencies = [
   "googletrans>=4.0.2",
   "howlongtobeatpy~=1.0.22",
   "ijson~=3.5.1",
+  "libsql>=0.1.11",
   "python-dotenv~=1.2.2",
   "python-telegram-bot[job-queue,rate-limiter,webhooks]~=22.8",
   "telegramify-markdown~=1.2.0",
-  "libsql>=0.1.11",
   "yt-dlp~=2026.7.4",
 ]
 

--- a/src/backfill_chat_search_windows.py
+++ b/src/backfill_chat_search_windows.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
@@ -26,10 +25,9 @@ async def backfill() -> None:
         source_chat_ids,
     )
 
-    api_key = os.environ["OPENROUTER_API_KEY"]
     chat_ids = args.chat_id or await source_chat_ids()
     if args.refresh:
-        print(f"indexed_windows={await refresh_windows(api_key, chat_ids):,}")
+        print(f"indexed_windows={await refresh_windows(chat_ids):,}")
         return
 
     total_inserted = 0
@@ -38,7 +36,6 @@ async def backfill() -> None:
         if args.limit_windows is not None:
             batch_limit = min(batch_limit, args.limit_windows - total_inserted)
         inserted = await index_pending_windows(
-            api_key,
             chat_ids=chat_ids,
             window_limit=batch_limit,
         )

--- a/src/commands/ai.py
+++ b/src/commands/ai.py
@@ -1,95 +1,142 @@
-import json
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
-import aiohttp
+import ai
+import pydantic
+from ai.providers.openai import OpenAICompatibleProvider
+from ai.types.messages import Message
 
 from commands.model import get_model, get_thinking, normalize_model_name
 from config.options import config
 
-OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
-type JsonObject = dict[str, object]
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_HEADERS = {
+    "X-Title": "SuperSeriousBot",
+    "HTTP-Referer": "https://superserio.us",
+}
+OPENROUTER_WEB_SEARCH = {
+    "type": "openrouter:web_search",
+    "parameters": {
+        "engine": "native",
+        "max_total_results": 20,
+    },
+}
+
+_provider: OpenAICompatibleProvider | None = None
 
 
-def openrouter_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-        "X-Title": "SuperSeriousBot",
-        "HTTP-Referer": "https://superserio.us",
-    }
+def openrouter_provider() -> OpenAICompatibleProvider:
+    global _provider
+    if _provider is None:
+        provider = ai.get_provider(
+            "openai",
+            base_url=OPENROUTER_BASE_URL,
+            api_key=config.API.OPENROUTER_API_KEY,
+            headers=OPENROUTER_HEADERS,
+        )
+        if not isinstance(provider, OpenAICompatibleProvider):
+            raise TypeError("OpenRouter requires an OpenAI-compatible provider.")
+        _provider = provider
+    return _provider
 
 
-def openrouter_api_key() -> str:
-    return config.API.OPENROUTER_API_KEY
+async def close_ai_provider() -> None:
+    global _provider
+    if _provider is not None:
+        await _provider.aclose()
+        _provider = None
 
 
-async def openrouter_payload(
+async def request_params(
     command: str,
-    messages: list[JsonObject],
     *,
     max_tokens: int | None = None,
-    stream: bool = False,
-    modalities: list[str] | None = None,
-) -> JsonObject:
+    temperature: float | None = None,
+    extra_body: dict[str, object] | None = None,
+) -> ai.InferenceRequestParams:
+    body = dict(extra_body or {})
     model_name = normalize_model_name(await get_model(command))
-    payload: JsonObject = {"model": model_name, "messages": messages}
-    if max_tokens is not None:
-        payload["max_tokens"] = max_tokens
-    if stream:
-        payload["stream"] = True
-    if modalities:
-        payload["modalities"] = modalities
     if model_name.startswith("x-ai/"):
-        payload["plugins"] = [{"id": "web", "engine": "native"}]
+        body["tools"] = [OPENROUTER_WEB_SEARCH]
+
+    params = ai.InferenceRequestParams(
+        output=ai.OutputParams(max_tokens=max_tokens),
+        extra_body=body or None,
+    )
+    if temperature is not None:
+        params = params.with_temperature(temperature)
     if command == "ask" and (thinking_level := await get_thinking()) != "none":
-        payload["reasoning"] = {"effort": thinking_level}
-    return payload
+        params = params.with_reasoning_effort(thinking_level)
+    return params
 
 
-async def openrouter_json(
-    session: aiohttp.ClientSession,
-    payload: JsonObject,
-) -> JsonObject:
-    async with session.post(
-        OPENROUTER_API_URL,
-        headers=openrouter_headers(openrouter_api_key()),
-        json=payload,
-    ) as response:
-        response.raise_for_status()
-        data = await response.json()
-    return data if isinstance(data, dict) else {}
+async def model(command: str) -> ai.Model:
+    return ai.Model(
+        id=normalize_model_name(await get_model(command)),
+        provider=openrouter_provider(),
+    )
 
 
-async def stream_openrouter_deltas(
-    response: aiohttp.ClientResponse,
-) -> AsyncIterator[str]:
-    buffer = ""
-    async for chunk in response.content.iter_chunked(1024):
-        buffer += chunk.decode("utf-8", errors="ignore")
-        while "\n" in buffer:
-            line, buffer = buffer.split("\n", 1)
-            if not (line := line.strip()).startswith("data:"):
-                continue
-            if (data := line[5:].strip()) == "[DONE]":
-                return
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                continue
-            choices = payload.get("choices")
-            first_choice = choices[0] if isinstance(choices, list) and choices else None
-            delta = (
-                first_choice.get("delta") if isinstance(first_choice, dict) else None
-            )
-            content = delta.get("content") if isinstance(delta, dict) else None
-            if content:
-                yield content
+@asynccontextmanager
+async def stream_model(
+    command: str,
+    messages: list[Message],
+    *,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    extra_body: dict[str, object] | None = None,
+) -> AsyncIterator[ai.Stream[str]]:
+    async with ai.stream(
+        await model(command),
+        messages,
+        params=await request_params(
+            command,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extra_body=extra_body,
+        ),
+    ) as stream:
+        yield stream
 
 
-def first_message_content(response: JsonObject) -> object:
-    choices = response.get("choices")
-    choice = choices[0] if isinstance(choices, list) and choices else None
-    match choice:
-        case {"message": {"content": content}}:
-            return content
-    return None
+async def generate_text(
+    command: str,
+    messages: list[Message],
+    *,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    extra_body: dict[str, object] | None = None,
+) -> str:
+    async with stream_model(
+        command,
+        messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        extra_body=extra_body,
+    ) as stream:
+        async for _ in stream:
+            pass
+    return stream.output
+
+
+async def generate_object[OutputT: pydantic.BaseModel](
+    command: str,
+    messages: list[Message],
+    output_type: type[OutputT],
+    *,
+    max_tokens: int | None = None,
+    extra_body: dict[str, object] | None = None,
+) -> OutputT:
+    async with ai.stream(
+        await model(command),
+        messages,
+        output_type=output_type,
+        params=await request_params(
+            command,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
+        ),
+    ) as stream:
+        async for _ in stream:
+            pass
+    return stream.output

--- a/src/commands/ask.py
+++ b/src/commands/ask.py
@@ -5,23 +5,15 @@ import mimetypes
 import time
 from datetime import timedelta
 
-import aiohttp
+import ai
+import openai
 from telegram import Message, Update
 from telegram.constants import ChatType
 from telegram.error import BadRequest, RetryAfter, TelegramError
 from telegram.ext import ContextTypes
 
 import commands
-from commands.ai import (
-    OPENROUTER_API_URL,
-    JsonObject,
-    first_message_content,
-    openrouter_api_key,
-    openrouter_headers,
-    openrouter_json,
-    openrouter_payload,
-    stream_openrouter_deltas,
-)
+from commands.ai import model, openrouter_provider, stream_model
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
@@ -174,8 +166,7 @@ async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     query: str = " ".join(context.args) if context.args else ""
-    messages: list[JsonObject] = [{"role": "system", "content": system_prompt}]
-    user_content: list[JsonObject] = []
+    messages = [ai.system_message(system_prompt)]
 
     reply = message.reply_to_message
     reply_context = get_reply_context(reply)
@@ -200,124 +191,88 @@ async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if reply_image:
         image_data, mime_type = reply_image
-        image_url = image_data_url(image_data, mime_type)
-
         text_prompt = query if query else "Describe this image in detail."
         if reply_context:
             text_prompt = (
                 f"Reply context:\n{reply_context}\n\nUser request:\n{text_prompt}"
             )
-        user_content.append({"type": "text", "text": text_prompt})
-        user_content.append(
-            {
-                "type": "image_url",
-                "image_url": {"url": image_url},
-            }
+        messages.append(
+            ai.user_message(
+                text_prompt,
+                ai.file_part(image_data, media_type=mime_type or "image/jpeg"),
+            )
         )
-        messages.append({"role": "user", "content": user_content})
     else:
         if not query:
             await commands.usage_string(message, ask)
             return
         if reply_context:
             query = f"Reply context:\n{reply_context}\n\nUser request:\n{query}"
-        messages.append({"role": "user", "content": query})
+        messages.append(ai.user_message(query))
 
     try:
-        import aiohttp
+        is_group = message.chat.type in {ChatType.GROUP, ChatType.SUPERGROUP}
+        sent_message = None
+        prev_length = 0
+        content = ""
+        truncated = False
+        last_edit_time = 0.0
 
-        headers = openrouter_headers(openrouter_api_key())
-        payload = await openrouter_payload("ask", messages)
-
-        async with aiohttp.ClientSession() as session:
-            if reply_image:
-                response = await openrouter_json(session, payload)
-                text = first_message_content(response)
-                if not isinstance(text, str):
-                    await message.reply_text(
-                        "No response received from AI. Please try again."
-                    )
-                    return
-
-                await reply_markdown_or_plain(
-                    message,
-                    text,
-                    disable_web_page_preview=True,
-                    document_name="response.txt",
-                )
-                return
-
-            payload = await openrouter_payload("ask", messages, stream=True)
-            async with session.post(
-                OPENROUTER_API_URL, headers=headers, json=payload
-            ) as resp:
-                resp.raise_for_status()
-                is_group = message.chat.type in {
-                    ChatType.GROUP,
-                    ChatType.SUPERGROUP,
-                }
-                sent_message = None
-                prev_length = 0
-                content = ""
-                truncated = False
-                last_edit_time = 0.0
-
-                async for delta in stream_openrouter_deltas(resp):
-                    if not truncated:
-                        content += delta
-                        if len(content) >= TELEGRAM_MESSAGE_LIMIT:
-                            content = content[:TELEGRAM_MESSAGE_LIMIT]
-                            truncated = True
-
-                    if not content:
-                        continue
-
-                    if sent_message is None:
-                        sent_message = await reply_markdown_or_plain(
-                            message,
-                            content,
-                            disable_web_page_preview=True,
-                        )
-                        prev_length = len(content)
-                        continue
-
-                    if len(content) == prev_length:
-                        continue
-
-                    cutoff = get_stream_cutoff(is_group, len(content))
-                    if not truncated and (len(content) - prev_length) < cutoff:
-                        continue
-                    if (
-                        not truncated
-                        and (time.monotonic() - last_edit_time)
-                        < MIN_STREAM_EDIT_INTERVAL_SECONDS
-                    ):
-                        continue
-
-                    if await edit_stream_reply(
-                        context.bot,
-                        message.chat.id,
-                        sent_message.message_id,
-                        content,
-                    ):
-                        prev_length = len(content)
-                        last_edit_time = time.monotonic()
+        async with stream_model("ask", messages) as stream:
+            async for event in stream:
+                if not isinstance(event, ai.events.TextDelta):
+                    continue
+                if not truncated:
+                    content += event.chunk
+                    if len(content) >= TELEGRAM_MESSAGE_LIMIT:
+                        content = content[:TELEGRAM_MESSAGE_LIMIT]
+                        truncated = True
 
                 if not content:
-                    return
-
+                    continue
                 if sent_message is None:
-                    await message.reply_text(content, disable_web_page_preview=True)
-                    return
-
-                if len(content) != prev_length:
-                    await edit_stream_reply(
-                        context.bot,
-                        message.chat.id,
-                        sent_message.message_id,
+                    sent_message = await reply_markdown_or_plain(
+                        message,
                         content,
+                        disable_web_page_preview=True,
                     )
-    except (aiohttp.ClientError, TelegramError, TimeoutError, TypeError, ValueError):
+                    prev_length = len(content)
+                    continue
+                if len(content) == prev_length:
+                    continue
+
+                cutoff = get_stream_cutoff(is_group, len(content))
+                if not truncated and (len(content) - prev_length) < cutoff:
+                    continue
+                if (
+                    not truncated
+                    and (time.monotonic() - last_edit_time)
+                    < MIN_STREAM_EDIT_INTERVAL_SECONDS
+                ):
+                    continue
+                if await edit_stream_reply(
+                    context.bot,
+                    message.chat.id,
+                    sent_message.message_id,
+                    content,
+                ):
+                    prev_length = len(content)
+                    last_edit_time = time.monotonic()
+
+        if not content:
+            await message.reply_text("No response received from AI. Please try again.")
+            return
+        if sent_message is None:
+            await message.reply_text(content, disable_web_page_preview=True)
+            return
+        if len(content) != prev_length:
+            await edit_stream_reply(
+                context.bot,
+                message.chat.id,
+                sent_message.message_id,
+                content,
+            )
+    except (ai.AIError, TelegramError, TimeoutError, TypeError, ValueError):
         logger.exception("Ask command failed")
         await message.reply_text("AI request failed. Please try again.")
 
@@ -368,10 +323,10 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
         image_url = image_data_url(*reply_image)
 
-        headers = openrouter_headers(openrouter_api_key())
-        payload = await openrouter_payload(
-            "edit",
-            [
+        image_model = await model("edit")
+        response = await openrouter_provider().sdk_client.chat.completions.create(
+            model=image_model.id,
+            messages=[
                 {
                     "role": "user",
                     "content": [
@@ -383,23 +338,14 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     ],
                 }
             ],
-            modalities=["image", "text"],
+            extra_body={"modalities": ["image", "text"]},
         )
-
-        async with (
-            aiohttp.ClientSession() as session,
-            session.post(OPENROUTER_API_URL, headers=headers, json=payload) as resp,
-        ):
-            resp.raise_for_status()
-            response = await resp.json()
-
-        choices = response.get("choices")
-        choice = choices[0] if isinstance(choices, list) and choices else None
-        if not isinstance(choice, dict):
+        choice = response.choices[0] if response.choices else None
+        if choice is None:
             await message.reply_text("No response received from AI. Please try again.")
             return
 
-        finish_reason = choice.get("finish_reason", "")
+        finish_reason = choice.finish_reason or ""
         if finish_reason and str(finish_reason).upper() in {
             "CONTENT_FILTER",
             "SAFETY",
@@ -410,9 +356,9 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
             return
 
-        ai_message = choice.get("message")
-        if isinstance(ai_message, dict):
-            images = ai_message.get("images")
+        ai_message = choice.message
+        if ai_message.model_extra:
+            images = ai_message.model_extra.get("images")
             first_image = images[0] if isinstance(images, list) and images else None
             image_url_data = (
                 first_image.get("image_url", {}).get("url")
@@ -434,14 +380,14 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 )
                 return
 
-        if isinstance(ai_message, dict) and ai_message.get("content"):
+        if ai_message.content:
             await message.reply_text(
-                f"{ai_message['content']}\n\nNo edited image was generated."
+                f"{ai_message.content}\n\nNo edited image was generated."
             )
             return
 
         await message.reply_text("Could not generate edited image. Please try again.")
 
-    except (aiohttp.ClientError, TelegramError, TimeoutError, TypeError, ValueError):
+    except (openai.OpenAIError, TelegramError, TimeoutError, TypeError, ValueError):
         logger.exception("Edit command failed")
         await message.reply_text("AI request failed. Please try again.")

--- a/src/commands/cron.py
+++ b/src/commands/cron.py
@@ -1,7 +1,7 @@
 import datetime
 import html
 
-import aiohttp
+import ai
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
@@ -148,7 +148,7 @@ async def cron(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     status_message = await message.reply_text("Creating cron task...")
     try:
         draft = await generate_cron_draft(user_request)
-    except (aiohttp.ClientError, KeyError, RuntimeError, TypeError, ValueError) as exc:
+    except (ai.AIError, KeyError, RuntimeError, TypeError, ValueError) as exc:
         await status_message.edit_text(f"Could not create cron task: {exc}")
         return
 

--- a/src/commands/cron_service.py
+++ b/src/commands/cron_service.py
@@ -4,19 +4,15 @@ from dataclasses import dataclass
 from typing import Literal
 from zoneinfo import ZoneInfo
 
-import aiohttp
+import ai
+import pydantic
 from apscheduler.triggers.cron import CronTrigger
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import KeyboardButtonStyle
 from telegram.ext import ContextTypes, JobQueue
 
 import utils
-from commands.ai import (
-    JsonObject,
-    first_message_content,
-    openrouter_json,
-    openrouter_payload,
-)
+from commands.ai import generate_object, generate_text
 from config.db import get_db
 from config.logger import logger
 from utils.messages import send_markdown_or_plain
@@ -43,37 +39,6 @@ Previous runs are context only, not a template. If a previous run is incomplete,
 correct it in this run.
 Return the Telegram message to send. No scheduling metadata."""
 
-CRON_RESPONSE_FORMAT: JsonObject = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "cron_task",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "description": "Short title for the scheduled task.",
-                },
-                "task": {
-                    "type": "string",
-                    "description": "Complete instruction to execute on each run.",
-                },
-                "cron_expr": {
-                    "type": "string",
-                    "description": "Five-field crontab expression.",
-                },
-                "timezone": {
-                    "type": "string",
-                    "description": "IANA timezone.",
-                },
-            },
-            "required": ["title", "task", "cron_expr", "timezone"],
-            "additionalProperties": False,
-        },
-    },
-}
-
 
 @dataclass(frozen=True, slots=True)
 class CronDraft:
@@ -81,6 +46,13 @@ class CronDraft:
     task: str
     cron_expr: str
     timezone: str
+
+
+class CronDraftOutput(pydantic.BaseModel):
+    title: str = pydantic.Field(description="Short title for the scheduled task.")
+    task: str = pydantic.Field(description="Complete instruction to execute each run.")
+    cron_expr: str = pydantic.Field(description="Five-field crontab expression.")
+    timezone: str = pydantic.Field(description="IANA timezone.")
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,26 +130,16 @@ def _parse_cron_draft(content: str) -> CronDraft:
 
 async def generate_cron_draft(user_request: str) -> CronDraft:
     now = datetime.datetime.now(ZoneInfo(DEFAULT_TIMEZONE)).isoformat()
-    payload = await openrouter_payload(
+    output = await generate_object(
         "cron",
         [
-            {"role": "system", "content": SCHEDULER_SYSTEM_PROMPT},
-            {
-                "role": "user",
-                "content": f"Current time: {now}\n\nRequest:\n{user_request}",
-            },
+            ai.system_message(SCHEDULER_SYSTEM_PROMPT),
+            ai.user_message(f"Current time: {now}\n\nRequest:\n{user_request}"),
         ],
+        CronDraftOutput,
         max_tokens=500,
     )
-    payload["response_format"] = CRON_RESPONSE_FORMAT
-
-    async with aiohttp.ClientSession() as session:
-        response = await openrouter_json(session, payload)
-
-    content = first_message_content(response)
-    if not isinstance(content, str):
-        raise TypeError("AI returned no cron metadata.")
-    return _parse_cron_draft(content)
+    return _parse_cron_draft(output.model_dump_json())
 
 
 def _task_from_row(row) -> CronTask:
@@ -363,31 +325,26 @@ def format_run_history(runs: list[CronRun]) -> str:
     return "\n\n".join(lines)
 
 
-def build_runner_messages(task: CronTask, runs: list[CronRun]) -> list[JsonObject]:
+def build_runner_messages(
+    task: CronTask, runs: list[CronRun]
+) -> list[ai.messages.Message]:
     return [
-        {"role": "system", "content": RUNNER_SYSTEM_PROMPT},
-        {
-            "role": "user",
-            "content": (
-                f"Title: {task.title}\n\n"
-                f"Task:\n{task.task}\n\n"
-                f"Previous runs:\n{format_run_history(runs)}"
-            ),
-        },
+        ai.system_message(RUNNER_SYSTEM_PROMPT),
+        ai.user_message(
+            f"Title: {task.title}\n\n"
+            f"Task:\n{task.task}\n\n"
+            f"Previous runs:\n{format_run_history(runs)}"
+        ),
     ]
 
 
 async def execute_cron_task(task: CronTask, runs: list[CronRun]) -> str:
-    payload = await openrouter_payload(
+    content = await generate_text(
         "cron",
         build_runner_messages(task, runs),
         max_tokens=1000,
     )
-    async with aiohttp.ClientSession() as session:
-        response = await openrouter_json(session, payload)
-
-    content = first_message_content(response)
-    if not isinstance(content, str) or not content.strip():
+    if not content.strip():
         raise RuntimeError("AI returned no cron task result.")
     return content.strip()
 

--- a/src/commands/song.py
+++ b/src/commands/song.py
@@ -1,19 +1,16 @@
 import asyncio
-import json
 from dataclasses import dataclass
 from typing import Any
 
+import ai
 import aiohttp
+import pydantic
 from telegram import InputMediaAudio, Update
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
 import commands
-from commands.ai import (
-    first_message_content,
-    openrouter_json,
-    openrouter_payload,
-)
+from commands.ai import generate_object
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
@@ -38,6 +35,12 @@ type JsonObject = dict[str, Any]
 class SongPlan:
     title: str
     lyrics: str
+    style: str
+
+
+class SongPlanOutput(pydantic.BaseModel):
+    title: str
+    lyrics_lines: list[str] = pydantic.Field(alias="lyricsLines")
     style: str
 
 
@@ -97,89 +100,26 @@ async def kie_json(
         return data
 
 
-async def song_plan_payload(user_prompt: str) -> JsonObject:
-    payload = await openrouter_payload(
+async def plan_song(user_prompt: str) -> SongPlan:
+    output = await generate_object(
         "song",
         [
-            {"role": "system", "content": SONG_PLANNER_SYSTEM_PROMPT},
-            {"role": "user", "content": user_prompt},
+            ai.system_message(SONG_PLANNER_SYSTEM_PROMPT),
+            ai.user_message(user_prompt),
         ],
+        SongPlanOutput,
+        extra_body={"provider": {"require_parameters": True}},
     )
-    payload.update(
-        {
-            "provider": {"require_parameters": True},
-            "response_format": {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "song_plan",
-                    "strict": True,
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "type": "string",
-                            },
-                            "lyricsLines": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                            },
-                            "style": {
-                                "type": "string",
-                            },
-                        },
-                        "required": ["title", "lyricsLines", "style"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-        }
-    )
-    return payload
-
-
-def parse_song_plan_response(data: object) -> SongPlan:
-    response: JsonObject = {}
-    if isinstance(data, dict):
-        for key, value in data.items():
-            if isinstance(key, str):
-                response[key] = value
-    content = first_message_content(response)
-    if not isinstance(content, str):
-        raise TypeError("OpenRouter did not return a song plan.")
-
-    try:
-        plan = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("OpenRouter returned an invalid song plan.") from exc
-
-    title = plan.get("title") if isinstance(plan, dict) else None
-    lyrics_lines = plan.get("lyricsLines") if isinstance(plan, dict) else None
-    style = plan.get("style") if isinstance(plan, dict) else None
-    if (
-        not isinstance(title, str)
-        or not isinstance(lyrics_lines, list)
-        or not isinstance(style, str)
-    ):
-        raise TypeError("OpenRouter returned an incomplete song plan.")
-    if not all(isinstance(line, str) for line in lyrics_lines):
-        raise RuntimeError("OpenRouter returned invalid lyrics.")
-
-    lyrics = "\n".join(line.strip() for line in lyrics_lines if line.strip())
-    if not title.strip() or not lyrics or not style.strip():
+    lyrics = "\n".join(line.strip() for line in output.lyrics_lines if line.strip())
+    if not output.title.strip() or not lyrics or not output.style.strip():
         raise RuntimeError("OpenRouter returned an empty song plan.")
-    if len(title) > SONG_TITLE_CHAR_LIMIT:
+    if len(output.title) > SONG_TITLE_CHAR_LIMIT:
         raise RuntimeError("OpenRouter returned a title that was too long.")
     if len(lyrics) > SONG_LYRICS_CHAR_LIMIT:
         raise RuntimeError("OpenRouter returned lyrics that were too long.")
-    if len(style) > SONG_STYLE_CHAR_LIMIT:
+    if len(output.style) > SONG_STYLE_CHAR_LIMIT:
         raise RuntimeError("OpenRouter returned a style that was too long.")
-    return SongPlan(title.strip(), lyrics.strip(), style.strip())
-
-
-async def plan_song(session: aiohttp.ClientSession, user_prompt: str) -> SongPlan:
-    payload = await song_plan_payload(user_prompt)
-    data = await openrouter_json(session, payload)
-    return parse_song_plan_response(data)
+    return SongPlan(output.title.strip(), lyrics.strip(), output.style.strip())
 
 
 async def create_task(
@@ -281,7 +221,7 @@ async def song(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     try:
         async with aiohttp.ClientSession() as session:
-            song_plan = await plan_song(session, user_prompt)
+            song_plan = await plan_song(user_prompt)
 
             await progress.edit_text("Turning lyrics into songs...")
             music_task_id = await create_task(
@@ -318,6 +258,7 @@ async def song(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
     except (
         aiohttp.ClientError,
+        ai.AIError,
         RuntimeError,
         TelegramError,
         TimeoutError,

--- a/src/commands/tldr.py
+++ b/src/commands/tldr.py
@@ -1,13 +1,14 @@
 import html
 from urllib.parse import parse_qs, urlparse
 
+import ai
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
 import commands
 import utils
-from commands.ai import first_message_content, openrouter_json, openrouter_payload
+from commands.ai import generate_text
 from commands.runtime import ensure_command_available
 from config.db import get_db
 from config.logger import logger
@@ -46,7 +47,7 @@ def extract_youtube_video_id(url: str) -> str | None:
 
 async def summarize_text(text: str, context_hint: str = "") -> str:
     """Summarize text using AI."""
-    import aiohttp
+    import ai
 
     context = f" (source: {context_hint})" if context_hint else ""
     system_content = f"""Summarize the following content{context} as a short bullet-point list.
@@ -58,20 +59,15 @@ Rules:
 - Skip fluff, intros, and filler
 - No headers or extra formatting, just bullets"""
 
-    payload = await openrouter_payload(
+    content = await generate_text(
         "tldr",
         [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": text},
+            ai.system_message(system_content),
+            ai.user_message(text),
         ],
         max_tokens=500,
     )
-
-    async with aiohttp.ClientSession() as session:
-        response = await openrouter_json(session, payload)
-
-    content = first_message_content(response)
-    return str(content) if content else "No summary available"
+    return content or "No summary available"
 
 
 @command(
@@ -155,6 +151,7 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                     )
                 return
             except (
+                ai.AIError,
                 aiohttp.ClientError,
                 KeyError,
                 RuntimeError,
@@ -239,6 +236,7 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
             parse_mode=ParseMode.HTML,
         )
     except (
+        ai.AIError,
         aiohttp.ClientError,
         RuntimeError,
         TimeoutError,

--- a/src/commands/transcribe.py
+++ b/src/commands/transcribe.py
@@ -1,20 +1,16 @@
 import asyncio
-import base64
 import mimetypes
 import os
 import subprocess
 import tempfile
 
+import ai
 from telegram import Update
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
 import commands
-from commands.ai import (
-    OPENROUTER_API_URL,
-    openrouter_headers,
-    openrouter_payload,
-)
+from commands.ai import generate_text
 from commands.runtime import ensure_command_available
 from config.logger import logger
 from config.options import config
@@ -77,8 +73,6 @@ async def _convert_audio_to_wav(
     api_key="OPENROUTER_API_KEY",
 )
 async def transcribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    import aiohttp
-
     message = get_message(update)
     if not message:
         return
@@ -140,67 +134,25 @@ async def transcribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await message.reply_text("I couldn't process that audio.")
         return
 
-    base64_audio = base64.b64encode(wav_audio).decode("utf-8")
     user_prompt = " ".join(context.args).strip() if context.args else ""
     instruction = user_prompt or FALLBACK_PROMPT
 
-    payload = await openrouter_payload(
-        "tr",
-        [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": (
-                            f"You are transcribing a {source_summary}. {instruction}"
-                        ).strip(),
-                    },
-                    {
-                        "type": "input_audio",
-                        "input_audio": {"data": base64_audio, "format": "wav"},
-                    },
-                ],
-            }
-        ],
-    )
+    try:
+        transcript = await generate_text(
+            "tr",
+            [
+                ai.user_message(
+                    f"You are transcribing a {source_summary}. {instruction}".strip(),
+                    ai.file_part(wav_audio, media_type="audio/wav"),
+                )
+            ],
+        )
+    except (ai.AIError, TimeoutError, TypeError, ValueError):
+        logger.exception("Transcription request failed")
+        await message.reply_text("Transcription failed. Please try again.")
+        return
 
-    headers = openrouter_headers(api_key_value)
-
-    async with (
-        aiohttp.ClientSession() as session,
-        session.post(
-            OPENROUTER_API_URL,
-            headers=headers,
-            json=payload,
-        ) as response,
-    ):
-        if response.status != 200:
-            error_text = await response.text()
-            logger.error(
-                "Transcription request failed (%s): %s",
-                response.status,
-                error_text,
-            )
-            await message.reply_text("Transcription failed. Please try again.")
-            return
-
-        data = await response.json()
-
-    choices = data.get("choices") or []
-    content = choices[0].get("message", {}).get("content") if choices else None
-    if isinstance(content, str):
-        transcript = content.strip()
-    elif isinstance(content, list):
-        transcript = "\n".join(
-            item["text"]
-            for item in content
-            if isinstance(item, dict)
-            and item.get("type") == "text"
-            and item.get("text")
-        ).strip()
-    else:
-        transcript = ""
+    transcript = transcript.strip()
     if not transcript:
         await message.reply_text("No transcript was returned. Please try again.")
         return

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from telegram.ext import (
 )
 
 import commands
+from commands.ai import close_ai_provider
 from commands.cron_service import register_enabled_cron_tasks
 from commands.football import sync_football_fixtures_job, worker_football_alerts
 from commands.habit import worker_habit_tracker
@@ -73,13 +74,13 @@ async def post_shutdown(application: Application) -> None:
     Shutdown the bot.
     """
     logger.info(f"Shutting down @{application.bot.username} (ID: {application.bot.id})")
+    await close_ai_provider()
     await close_db()
     logger.info("Cleanup finished.")
 
 
 async def worker_chat_search_index(_: ContextTypes.DEFAULT_TYPE) -> None:
     indexed = await index_pending_windows(
-        config.API.OPENROUTER_API_KEY,
         chat_ids=await searchable_chat_ids(),
     )
     if indexed:

--- a/src/management/chat_search_index.py
+++ b/src/management/chat_search_index.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-import aiohttp
-
 from chat_search_config import (
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MODEL,
@@ -285,8 +283,6 @@ async def store_windows(
 
 
 async def index_window_batch(
-    session: aiohttp.ClientSession,
-    api_key: str,
     chat_id: int,
     start_message_id: int | None,
     window_limit: int,
@@ -303,8 +299,6 @@ async def index_window_batch(
     if not windows:
         return 0, None
     embeddings = await openrouter_embeddings(
-        session,
-        api_key,
         EMBEDDING_MODEL,
         [window.text for window in windows],
         dimensions=EMBEDDING_DIMENSIONS,
@@ -325,14 +319,10 @@ async def index_window_batch(
 
 
 async def index_chat_windows(
-    session: aiohttp.ClientSession,
-    api_key: str,
     chat_id: int,
     window_limit: int,
 ) -> int:
     indexed, _ = await index_window_batch(
-        session,
-        api_key,
         chat_id,
         await resume_window_start(chat_id),
         window_limit,
@@ -342,7 +332,6 @@ async def index_chat_windows(
 
 
 async def index_pending_windows(
-    api_key: str,
     *,
     chat_ids: list[int],
     window_limit: int = INDEX_BATCH_WINDOWS,
@@ -353,54 +342,40 @@ async def index_pending_windows(
     indexed = 0
     backlogged = []
     per_chat_limit = max(1, window_limit // len(chat_ids))
-    async with aiohttp.ClientSession() as session:
-        for chat_id in chat_ids:
-            remaining = window_limit - indexed
-            if remaining <= 0:
-                break
-            chat_limit = min(per_chat_limit, remaining)
-            chat_indexed = await index_chat_windows(
-                session,
-                api_key,
-                chat_id,
-                chat_limit,
-            )
-            indexed += chat_indexed
-            if chat_indexed == chat_limit:
-                backlogged.append(chat_id)
+    for chat_id in chat_ids:
+        remaining = window_limit - indexed
+        if remaining <= 0:
+            break
+        chat_limit = min(per_chat_limit, remaining)
+        chat_indexed = await index_chat_windows(chat_id, chat_limit)
+        indexed += chat_indexed
+        if chat_indexed == chat_limit:
+            backlogged.append(chat_id)
 
-        for chat_id in backlogged:
-            remaining = window_limit - indexed
-            if remaining <= 0:
-                break
-            indexed += await index_chat_windows(
-                session,
-                api_key,
-                chat_id,
-                remaining,
-            )
+    for chat_id in backlogged:
+        remaining = window_limit - indexed
+        if remaining <= 0:
+            break
+        indexed += await index_chat_windows(chat_id, remaining)
     await sync_search_cache()
     return indexed
 
 
-async def refresh_windows(api_key: str, chat_ids: list[int]) -> int:
+async def refresh_windows(chat_ids: list[int]) -> int:
     refreshed = 0
-    async with aiohttp.ClientSession() as session:
-        for chat_id in chat_ids:
-            start_message_id = None
-            while True:
-                batch_size, next_start_message_id = await index_window_batch(
-                    session,
-                    api_key,
-                    chat_id,
-                    start_message_id,
-                    INDEX_BATCH_WINDOWS,
-                    skip_indexed=False,
-                )
-                refreshed += batch_size
-                if batch_size < INDEX_BATCH_WINDOWS or next_start_message_id is None:
-                    break
-                start_message_id = next_start_message_id
+    for chat_id in chat_ids:
+        start_message_id = None
+        while True:
+            batch_size, next_start_message_id = await index_window_batch(
+                chat_id,
+                start_message_id,
+                INDEX_BATCH_WINDOWS,
+                skip_indexed=False,
+            )
+            refreshed += batch_size
+            if batch_size < INDEX_BATCH_WINDOWS or next_start_message_id is None:
+                break
+            start_message_id = next_start_message_id
     reset_search_cache()
     await sync_search_cache()
     return refreshed

--- a/src/management/chat_semantic_search.py
+++ b/src/management/chat_semantic_search.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import dataclass
 from itertools import groupby
 
-import aiohttp
+import ai
 
 from chat_search_config import (
     ANSWER_EVIDENCE_COUNT,
@@ -14,18 +14,12 @@ from chat_search_config import (
     QUERY_INSTRUCTION,
     VECTOR_RESULT_COUNT,
 )
-from commands.ai import first_message_content
-from commands.model import get_model, normalize_model_name
+from commands.ai import generate_text
 from config.db import TursoRow, get_db
 from config.logger import logger
-from config.options import config
 from management.chat_search_cache import open_search_cache
 from management.chat_search_index import format_author
-from openrouter_embeddings import (
-    openrouter_api_headers,
-    openrouter_embeddings,
-    vector32_json,
-)
+from openrouter_embeddings import openrouter_embeddings, vector32_json
 
 _CITATION_RE = re.compile(r"(?P<space>[ \t]*)\[(?P<index>\d+)(?::[^]\s]+)?](?!\()")
 
@@ -53,10 +47,8 @@ def telegram_message_link(chat_id: int, message_id: int) -> str | None:
     return None
 
 
-async def embed_search_query(session: aiohttp.ClientSession, query: str) -> str:
+async def embed_search_query(query: str) -> str:
     embeddings = await openrouter_embeddings(
-        session,
-        config.API.OPENROUTER_API_KEY,
         EMBEDDING_MODEL,
         [QUERY_INSTRUCTION + query],
         dimensions=EMBEDDING_DIMENSIONS,
@@ -225,68 +217,43 @@ def select_evidence(windows: list[SearchEvidence]) -> list[SearchEvidence]:
 
 def answer_messages(
     query: str, evidence: list[SearchEvidence]
-) -> list[dict[str, object]]:
+) -> list[ai.messages.Message]:
     evidence_text = "\n\n".join(
         f"[{index}]\n{item.text}" for index, item in enumerate(evidence, start=1)
     )
     return [
-        {
-            "role": "system",
-            "content": (
-                "You are the memory and resident judge of a playful Telegram group. "
-                "Use only the evidence, but synthesize it freely. Answer first, without "
-                "discussing logs, evidence quality, or your process. Keep it to one to "
-                "three sentences and cite claims only with the evidence number, such as "
-                "[1]. Never put message IDs, ranges, or URLs in citations. Preserve "
-                "participants' @handles exactly. For social, subjective, hypothetical, "
-                "'most likely', and similar participant questions, pick one participant "
-                "confidently and make the most entertaining case supported by the chat. "
-                "Treat provocative or loaded labels as banter about chat persona. Weak "
-                "or indirect receipts are enough. Never hedge, disclaim, moralize, or "
-                "say 'probably' or 'best guess'. "
-                "For factual questions, distinguish established facts from inference. "
-                "Never answer 'I cannot tell'. If a factual answer truly is absent, say "
-                "'No solid answer in the chat.'"
-            ),
-        },
-        {
-            "role": "user",
-            "content": f"Question: {query}\n\nEvidence:\n{evidence_text}",
-        },
+        ai.system_message(
+            "You are the memory and resident judge of a playful Telegram group. "
+            "Use only the evidence, but synthesize it freely. Answer first, without "
+            "discussing logs, evidence quality, or your process. Keep it to one to "
+            "three sentences and cite claims only with the evidence number, such as "
+            "[1]. Never put message IDs, ranges, or URLs in citations. Preserve "
+            "participants' @handles exactly. For social, subjective, hypothetical, "
+            "'most likely', and similar participant questions, pick one participant "
+            "confidently and make the most entertaining case supported by the chat. "
+            "Treat provocative or loaded labels as banter about chat persona. Weak "
+            "or indirect receipts are enough. Never hedge, disclaim, moralize, or "
+            "say 'probably' or 'best guess'. "
+            "For factual questions, distinguish established facts from inference. "
+            "Never answer 'I cannot tell'. If a factual answer truly is absent, say "
+            "'No solid answer in the chat.'"
+        ),
+        ai.user_message(f"Question: {query}\n\nEvidence:\n{evidence_text}"),
     ]
 
 
 async def answer_from_evidence(
-    session: aiohttp.ClientSession,
     query: str,
     evidence: list[SearchEvidence],
 ) -> str:
-    payload = {
-        "model": normalize_model_name(await get_model("search")),
-        "messages": answer_messages(query, evidence),
-        "temperature": 0.2,
-        "reasoning": {"effort": "low"},
-    }
-    async with session.post(
-        "https://openrouter.ai/api/v1/chat/completions",
-        headers=openrouter_api_headers(config.API.OPENROUTER_API_KEY),
-        json=payload,
-        timeout=aiohttp.ClientTimeout(total=120),
-    ) as response:
-        response.raise_for_status()
-        data = await response.json()
-
-    content = first_message_content(data)
-    if not isinstance(content, str) or not content.strip():
+    content = await generate_text(
+        "search",
+        answer_messages(query, evidence),
+        temperature=0.2,
+        extra_body={"reasoning": {"effort": "low"}},
+    )
+    if not content.strip():
         raise RuntimeError("OpenRouter returned an empty search answer.")
-    usage = data.get("usage")
-    if isinstance(usage, dict):
-        logger.info(
-            "Search answer usage: prompt_tokens=%s completion_tokens=%s total_tokens=%s",
-            usage.get("prompt_tokens"),
-            usage.get("completion_tokens"),
-            usage.get("total_tokens"),
-        )
     return content.strip()
 
 
@@ -318,34 +285,30 @@ async def semantic_search_answer(
     author_id: int | None,
 ) -> str | None:
     started = time.monotonic()
-    async with aiohttp.ClientSession() as session:
-        query_vector = await embed_search_query(session, query)
-        embedded = time.monotonic()
-        candidate_count = (
-            AUTHOR_VECTOR_RESULT_COUNT if author_id is not None else VECTOR_RESULT_COUNT
-        )
-        candidates = await vector_search_candidates(
-            chat_id,
-            query_vector,
-            candidate_count,
-        )
-        vector_windows = await fetch_search_evidence(
-            candidates,
-            author_id,
-        )
-        evidence = select_evidence(vector_windows)
-        if not evidence:
-            return None
+    query_vector = await embed_search_query(query)
+    embedded = time.monotonic()
+    candidate_count = (
+        AUTHOR_VECTOR_RESULT_COUNT if author_id is not None else VECTOR_RESULT_COUNT
+    )
+    candidates = await vector_search_candidates(
+        chat_id,
+        query_vector,
+        candidate_count,
+    )
+    vector_windows = await fetch_search_evidence(candidates, author_id)
+    evidence = select_evidence(vector_windows)
+    if not evidence:
+        return None
 
-        retrieved = time.monotonic()
-        answer = await answer_from_evidence(session, query, evidence)
-        answered = time.monotonic()
-        logger.info(
-            "Semantic search timings: chat_id=%s embedding_ms=%d retrieval_ms=%d answer_ms=%d evidence=%d",
-            chat_id,
-            round((embedded - started) * 1000),
-            round((retrieved - embedded) * 1000),
-            round((answered - retrieved) * 1000),
-            len(evidence),
-        )
-        return link_citations(answer, evidence)
+    retrieved = time.monotonic()
+    answer = await answer_from_evidence(query, evidence)
+    answered = time.monotonic()
+    logger.info(
+        "Semantic search timings: chat_id=%s embedding_ms=%d retrieval_ms=%d answer_ms=%d evidence=%d",
+        chat_id,
+        round((embedded - started) * 1000),
+        round((retrieved - embedded) * 1000),
+        round((answered - retrieved) * 1000),
+        len(evidence),
+    )
+    return link_citations(answer, evidence)

--- a/src/openrouter_embeddings.py
+++ b/src/openrouter_embeddings.py
@@ -1,52 +1,26 @@
 import json
 
-import aiohttp
-
-OPENROUTER_EMBEDDINGS_API_URL = "https://openrouter.ai/api/v1/embeddings"
-OPENROUTER_TITLE = "SuperSeriousBot"
-OPENROUTER_REFERER = "https://superserio.us"
-
-
-def openrouter_api_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-        "X-Title": OPENROUTER_TITLE,
-        "HTTP-Referer": OPENROUTER_REFERER,
-    }
+from commands.ai import openrouter_provider
 
 
 async def openrouter_embeddings(
-    session: aiohttp.ClientSession,
-    api_key: str,
     model: str,
     inputs: list[str],
     *,
     dimensions: int,
 ) -> list[list[float]]:
-    payload = {
-        "model": model,
-        "input": inputs,
-        "dimensions": dimensions,
-        "provider": {"sort": "latency"},
-    }
-    async with session.post(
-        OPENROUTER_EMBEDDINGS_API_URL,
-        headers=openrouter_api_headers(api_key),
-        json=payload,
-        timeout=aiohttp.ClientTimeout(total=120),
-    ) as response:
-        response.raise_for_status()
-        data = await response.json()
-
-    embeddings = []
-    for item in data["data"]:
-        embedding = item["embedding"]
+    response = await openrouter_provider().sdk_client.embeddings.create(
+        model=model,
+        input=inputs,
+        dimensions=dimensions,
+        extra_body={"provider": {"sort": "latency"}},
+    )
+    embeddings = [item.embedding for item in response.data]
+    for embedding in embeddings:
         if len(embedding) != dimensions:
             raise RuntimeError(
                 f"Expected {dimensions} embedding dimensions, got {len(embedding)}"
             )
-        embeddings.append(embedding)
     return embeddings
 
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,48 @@
+import importlib
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+os.environ.setdefault("QUOTE_CHANNEL_ID", "1")
+os.environ.setdefault("TURSO_DATABASE_URL", ":memory:")
+os.environ.setdefault("TURSO_AUTH_TOKEN", "test-token")
+
+ai_module = importlib.import_module("commands.ai")
+
+
+class AIRequestTests(unittest.IsolatedAsyncioTestCase):
+    async def test_xai_models_use_native_agentic_web_search(self):
+        with (
+            patch.object(
+                ai_module,
+                "get_model",
+                AsyncMock(return_value="openrouter/x-ai/grok-4.3"),
+            ),
+            patch.object(
+                ai_module,
+                "get_thinking",
+                AsyncMock(return_value="medium"),
+            ),
+        ):
+            params = await ai_module.request_params("ask")
+
+        self.assertEqual(
+            params.extra_body,
+            {"tools": [ai_module.OPENROUTER_WEB_SEARCH]},
+        )
+        self.assertEqual(params.reasoning.effort, "medium")
+
+    async def test_other_models_do_not_receive_openrouter_web_tool(self):
+        with patch.object(
+            ai_module,
+            "get_model",
+            AsyncMock(return_value="openrouter/google/gemini-3-flash-preview"),
+        ):
+            params = await ai_module.request_params("tldr")
+
+        self.assertIsNone(params.extra_body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
@@ -93,7 +94,7 @@ class SemanticSearchTests(unittest.TestCase):
             [semantic_search.SearchEvidence(-1001, 1, 24, 24, "chat", 0.8)],
         )
 
-        prompt = messages[0]["content"]
+        prompt = messages[0].text
         self.assertIn("pick one participant confidently", prompt)
         self.assertIn("banter about chat persona", prompt)
         self.assertIn("Weak or indirect receipts are enough", prompt)
@@ -122,48 +123,24 @@ class SemanticSearchTests(unittest.TestCase):
 
 
 class SearchAnswerTests(unittest.IsolatedAsyncioTestCase):
-    async def test_answer_uses_configured_search_model(self):
-        class Response:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *_args):
-                return None
-
-            def raise_for_status(self):
-                return None
-
-            async def json(self):
-                return {"choices": [{"message": {"content": "answer"}}]}
-
-        class Session:
-            def __init__(self):
-                self.payload = None
-
-            def post(self, _url, *, headers, json, timeout):
-                self.payload = json
-                return Response()
-
-        session = Session()
+    async def test_answer_uses_low_reasoning(self):
         evidence = [
             semantic_search.SearchEvidence(-1001, 1, 24, 24, "chat", 0.8),
         ]
 
         with patch.object(
             semantic_search,
-            "get_model",
-            AsyncMock(return_value="openrouter/google/gemini-3-flash-preview"),
-        ):
-            answer = await semantic_search.answer_from_evidence(
-                session,
-                "question",
-                evidence,
-            )
+            "generate_text",
+            AsyncMock(return_value="answer"),
+        ) as generate_text:
+            answer = await semantic_search.answer_from_evidence("question", evidence)
 
         self.assertEqual(answer, "answer")
-        self.assertEqual(session.payload["model"], "google/gemini-3-flash-preview")
-        self.assertEqual(session.payload["reasoning"], {"effort": "low"})
-        self.assertNotIn("max_tokens", session.payload)
+        self.assertEqual(generate_text.await_args.args[0], "search")
+        self.assertEqual(
+            generate_text.await_args.kwargs["extra_body"],
+            {"reasoning": {"effort": "low"}},
+        )
 
 
 class SearchCacheTests(unittest.IsolatedAsyncioTestCase):
@@ -357,58 +334,38 @@ class SearchCacheTests(unittest.IsolatedAsyncioTestCase):
 
 class OpenRouterEmbeddingTests(unittest.IsolatedAsyncioTestCase):
     async def test_embeddings_prefer_low_latency_provider(self):
-        class Response:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *_args):
-                return None
-
-            def raise_for_status(self):
-                return None
-
-            async def json(self):
-                return {"data": [{"embedding": [1.0, 0.0]}]}
-
-        class Session:
-            def __init__(self):
-                self.payload = None
-
-            def post(self, _url, *, headers, json, timeout):
-                self.payload = json
-                return Response()
-
-        session = Session()
-
-        await openrouter_embeddings.openrouter_embeddings(
-            session,
-            "key",
-            "model",
-            ["query"],
-            dimensions=2,
+        response = SimpleNamespace(
+            data=[SimpleNamespace(embedding=[1.0, 0.0])],
+        )
+        create = AsyncMock(return_value=response)
+        provider = SimpleNamespace(
+            sdk_client=SimpleNamespace(
+                embeddings=SimpleNamespace(create=create),
+            )
         )
 
-        self.assertEqual(session.payload["provider"], {"sort": "latency"})
+        with patch.object(
+            openrouter_embeddings,
+            "openrouter_provider",
+            return_value=provider,
+        ):
+            embeddings = await openrouter_embeddings.openrouter_embeddings(
+                "model",
+                ["query"],
+                dimensions=2,
+            )
+
+        self.assertEqual(embeddings, [[1.0, 0.0]])
+        self.assertEqual(
+            create.await_args.kwargs["extra_body"],
+            {"provider": {"sort": "latency"}},
+        )
 
 
 class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
     async def test_pending_indexing_allocates_each_chat_a_share(self):
-        class SessionContext:
-            async def __aenter__(self):
-                return object()
-
-            async def __aexit__(self, *_: object):
-                return None
-
-        index_chat_windows = AsyncMock(
-            side_effect=lambda _session, _key, _chat_id, limit: limit
-        )
+        index_chat_windows = AsyncMock(side_effect=lambda _chat_id, limit: limit)
         with (
-            patch.object(
-                search_index.aiohttp,
-                "ClientSession",
-                return_value=SessionContext(),
-            ),
             patch.object(
                 search_index,
                 "index_chat_windows",
@@ -417,7 +374,6 @@ class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
             patch.object(search_index, "sync_search_cache", AsyncMock()),
         ):
             indexed = await search_index.index_pending_windows(
-                "key",
                 chat_ids=[-1002, -1001],
                 window_limit=6,
             )
@@ -425,27 +381,15 @@ class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(indexed, 6)
         self.assertEqual(
             [
-                (call.args[2], call.args[3])
+                (call.args[0], call.args[1])
                 for call in index_chat_windows.await_args_list
             ],
             [(-1002, 3), (-1001, 3)],
         )
 
     async def test_refresh_advances_without_clearing_existing_windows(self):
-        class SessionContext:
-            async def __aenter__(self):
-                return object()
-
-            async def __aexit__(self, *_: object):
-                return None
-
         index_window_batch = AsyncMock(side_effect=[(64, 100), (2, 200)])
         with (
-            patch.object(
-                search_index.aiohttp,
-                "ClientSession",
-                return_value=SessionContext(),
-            ),
             patch.object(
                 search_index,
                 "index_window_batch",
@@ -454,11 +398,11 @@ class SearchIndexTests(unittest.IsolatedAsyncioTestCase):
             patch.object(search_index, "reset_search_cache"),
             patch.object(search_index, "sync_search_cache", AsyncMock()),
         ):
-            refreshed = await search_index.refresh_windows("key", [-1001])
+            refreshed = await search_index.refresh_windows([-1001])
 
         self.assertEqual(refreshed, 66)
         self.assertEqual(
-            [call.args[3] for call in index_window_batch.await_args_list],
+            [call.args[1] for call in index_window_batch.await_args_list],
             [None, 100],
         )
 

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -1,63 +1,39 @@
 from __future__ import annotations
 
 import importlib
-import json
 import os
 import unittest
 from unittest.mock import AsyncMock, patch
+
+import pydantic
 
 os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
 os.environ.setdefault("QUOTE_CHANNEL_ID", "1")
 os.environ.setdefault("OPENROUTER_API_KEY", "test-openrouter-key")
 
-ai_module = importlib.import_module("commands.ai")
 song_module = importlib.import_module("commands.song")
-
-
-def openrouter_response(content: object) -> dict[str, object]:
-    return {
-        "choices": [
-            {
-                "message": {
-                    "content": json.dumps(content),
-                },
-            },
-        ],
-    }
-
-
-def song_plan_schema(payload: dict[str, object]) -> dict[str, object]:
-    response_format = payload["response_format"]
-    response_format = string_dict(response_format)
-    json_schema = response_format["json_schema"]
-    json_schema = string_dict(json_schema)
-    schema = json_schema["schema"]
-    return string_dict(schema)
-
-
-def string_dict(value: object) -> dict[str, object]:
-    assert isinstance(value, dict)
-    return {key: item for key, item in value.items() if isinstance(key, str)}
 
 
 class SongTests(unittest.IsolatedAsyncioTestCase):
     async def test_parse_song_plan_joins_lyric_lines(self):
-        plan = song_module.parse_song_plan_response(
-            openrouter_response(
-                {
-                    "title": "Online Fever",
-                    "lyricsLines": [
-                        "[Verse 1]",
-                        "Screen light",
-                        "Midnight",
-                        "[Chorus]",
-                        "Online",
-                        "Heart shine",
-                    ],
-                    "style": "upbeat Urdu pop, bright synths, catchy hook",
-                }
-            )
+        output = song_module.SongPlanOutput(
+            title="Online Fever",
+            lyricsLines=[
+                "[Verse 1]",
+                "Screen light",
+                "Midnight",
+                "[Chorus]",
+                "Online",
+                "Heart shine",
+            ],
+            style="upbeat Urdu pop, bright synths, catchy hook",
         )
+        with patch.object(
+            song_module,
+            "generate_object",
+            AsyncMock(return_value=output),
+        ) as generate_object:
+            plan = await song_module.plan_song("spreadsheet party")
 
         self.assertEqual(plan.title, "Online Fever")
         self.assertEqual(
@@ -65,41 +41,29 @@ class SongTests(unittest.IsolatedAsyncioTestCase):
             "[Verse 1]\nScreen light\nMidnight\n[Chorus]\nOnline\nHeart shine",
         )
         self.assertEqual(plan.style, "upbeat Urdu pop, bright synths, catchy hook")
-
-    async def test_song_plan_payload_requests_portable_schema(self):
-        with patch.object(
-            ai_module,
-            "get_model",
-            AsyncMock(return_value="openrouter/anthropic/claude-sonnet-4"),
-        ):
-            payload = await song_module.song_plan_payload("spreadsheet party")
-        schema = song_plan_schema(payload)
-        properties = schema["properties"]
-        properties = string_dict(properties)
-        lyrics_lines = properties["lyricsLines"]
-        lyrics_lines = string_dict(lyrics_lines)
-
-        self.assertNotIn("max_tokens", payload)
-        self.assertEqual(payload["model"], "anthropic/claude-sonnet-4")
-        self.assertEqual(schema["required"], ["title", "lyricsLines", "style"])
-        self.assertEqual(properties["title"], {"type": "string"})
         self.assertEqual(
-            lyrics_lines,
-            {"type": "array", "items": {"type": "string"}},
-        )
-        self.assertEqual(properties["style"], {"type": "string"})
-
-    async def test_parse_song_plan_rejects_non_string_lyric_lines(self):
-        response = openrouter_response(
-            {
-                "title": "Bad Lines",
-                "lyricsLines": ["[Verse 1]", 7],
-                "style": "bright pop",
-            }
+            generate_object.await_args.kwargs["extra_body"],
+            {"provider": {"require_parameters": True}},
         )
 
-        with self.assertRaisesRegex(RuntimeError, "invalid lyrics"):
-            song_module.parse_song_plan_response(response)
+    def test_song_plan_output_uses_portable_schema(self):
+        schema = song_module.SongPlanOutput.model_json_schema()
+        properties = schema["properties"]
+        self.assertEqual(schema["required"], ["title", "lyricsLines", "style"])
+        self.assertEqual(properties["title"]["type"], "string")
+        self.assertEqual(
+            properties["lyricsLines"],
+            {"items": {"type": "string"}, "title": "Lyricslines", "type": "array"},
+        )
+        self.assertEqual(properties["style"]["type"], "string")
+
+    def test_song_plan_output_rejects_non_string_lyric_lines(self):
+        with self.assertRaises(pydantic.ValidationError):
+            song_module.SongPlanOutput(
+                title="Bad Lines",
+                lyricsLines=["[Verse 1]", 7],
+                style="bright pop",
+            )
 
     def test_song_media_group_requires_two_audio_tracks(self):
         tracks = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,26 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ai"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "modelsdotdev" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
+]
+
+[package.optional-dependencies]
+openai = [
+    { name = "openai" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -127,6 +147,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6f/90/f0d1ef74a0c022ac64b42d8a278c8f9cbdf2d5049a8f1e7707f4c5f80358/aiounittest-1.5.0.tar.gz", hash = "sha256:3c20ab00909419749061a4cb1a2755f034d10c1f6455adb1f03d7c16dedce711", size = 7396, upload-time = "2025-03-07T07:33:58.648Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b6/5a02761969f8bf2c8263ce413c6253cb51a7224559c45608fa8f83e00f3a/aiounittest-1.5.0-py3-none-any.whl", hash = "sha256:30e709730e010c7daa1a0e3ce7398beebd2977d4dbf0a2875b8ed55830ab9d34", size = 7027, upload-time = "2025-03-07T07:33:57.381Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
@@ -275,6 +304,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -535,6 +573,56 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
 name = "libsql"
 version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +633,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/09/a36482f773943c45a6659bcb58be11ec7c1157876b908ea9eccf16c7a553/libsql-0.1.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c9ac431078a4eb82257541c764befa84782d8c5fbd1d1147e77f2906c28c444", size = 5110482, upload-time = "2025-09-02T10:13:25.669Z" },
     { url = "https://files.pythonhosted.org/packages/a6/7e/8496944f42f5b91a0e0938205297fc11896f6003f92caa5c53eaa2b8440f/libsql-0.1.11-cp313-cp313-win_amd64.whl", hash = "sha256:c61f6c4a73d799e4bedc49eb9b18bc8b6574267046195963684688f6a184632b", size = 4056117, upload-time = "2025-09-02T10:13:28.806Z" },
     { url = "https://files.pythonhosted.org/packages/d8/ad/cb4e9ac36693a9f3f3f9b03f2b1f0d14cf5b1b449c66be6f9ce7845cbf02/libsql-0.1.11-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c7b39b90228637a4b26293af44833633c36c091276fc8b58f216dea38742f23", size = 5110968, upload-time = "2025-09-02T10:13:30.228Z" },
+]
+
+[[package]]
+name = "modelsdotdev"
+version = "0.20260610.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/56/1505bb4d88d8c30261a2402c28ef9a7c8898bd428259ce9857931fc00603/modelsdotdev-0.20260610.0.tar.gz", hash = "sha256:f5e2d4e4c9b0a361d3e15d85e2c0fbacc787a7bdc66905807626953f3e22df9a", size = 815116, upload-time = "2026-06-10T16:38:42.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/0b/8cc67217511c8cbb4f997095b9abe7742627b412a1baf021a5991739a20a/modelsdotdev-0.20260610.0-py3-none-any.whl", hash = "sha256:d2595fcd3845d10b67b341d1f68b6cf25f573e89bf6f3a1e00bf81a816b909b4", size = 821929, upload-time = "2026-06-10T16:38:40.748Z" },
 ]
 
 [[package]]
@@ -626,6 +723,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/f5/e7735f2af272ee179a287911a698b3cbdb59d7a4ac4874571363adf1e4de/openai-2.50.0.tar.gz", hash = "sha256:5128f7caf4a6b01aefd6e7e93efe170a2c3427b8de286b9af5cdff3aa47e02c8", size = 1081965, upload-time = "2026-07-28T22:16:31.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/ca/db315b3bb748c26c644a3f85b7d509e774354d6518d47080b1446005ee41/openai-2.50.0-py3-none-any.whl", hash = "sha256:90bdddcc5a2fa529b350fac9c5780d87e5c361dcc6090ab57b0d470b0d7af7fa", size = 1650721, upload-time = "2026-07-28T22:16:29.48Z" },
 ]
 
 [[package]]
@@ -721,6 +837,77 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
 ]
 
 [[package]]
@@ -1019,6 +1206,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1032,6 +1228,7 @@ name = "superseriousbot"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "ai", extra = ["openai"] },
     { name = "aiohttp" },
     { name = "async-lru" },
     { name = "coloredlogs" },
@@ -1055,6 +1252,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ai", extras = ["openai"], specifier = "~=0.4.0" },
     { name = "aiohttp", specifier = "~=3.14.3" },
     { name = "async-lru", specifier = "~=2.3.0" },
     { name = "coloredlogs", specifier = ">=15.0.1" },
@@ -1106,6 +1304,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.63"
 source = { registry = "https://pypi.org/simple" }
@@ -1137,6 +1347,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace hand-written OpenRouter completion and SSE code with Vercel AI SDK for Python
- switch xAI models from the deprecated one-shot web plugin to `openrouter:web_search` with native xAI search
- route audio, structured outputs, image editing, and embeddings through one configured OpenRouter provider

## Proof
- `uv run ruff check src tests`
- `uv run ty check`
- `uv run pytest -q` — 88 passed
- live `/ask`-level smoke: 2 native web searches in one request (`web_search_requests: 2`)
- live embedding smoke: one 32-dimension vector
- autoreview: clean, no actionable findings