### PR TITLE
fix(ai): speak Chat Completions to OpenRouter

### DIFF
--- a/src/commands/ai.py
+++ b/src/commands/ai.py
@@ -3,7 +3,10 @@ from contextlib import asynccontextmanager
 
 import ai
 import pydantic
-from ai.providers.openai import OpenAICompatibleProvider
+from ai.providers.openai import (
+    OpenAIChatCompletionsProtocol,
+    OpenAICompatibleProvider,
+)
 from ai.types.messages import Message
 
 from commands.model import get_model, get_thinking, normalize_model_name
@@ -33,6 +36,7 @@ def openrouter_provider() -> OpenAICompatibleProvider:
             base_url=OPENROUTER_BASE_URL,
             api_key=config.API.OPENROUTER_API_KEY,
             headers=OPENROUTER_HEADERS,
+            protocol=OpenAIChatCompletionsProtocol(),
         )
         if not isinstance(provider, OpenAICompatibleProvider):
             raise TypeError("OpenRouter requires an OpenAI-compatible provider.")

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -3,6 +3,8 @@ import os
 import unittest
 from unittest.mock import AsyncMock, patch
 
+from ai.providers.openai import OpenAIChatCompletionsProtocol
+
 os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
 os.environ.setdefault("QUOTE_CHANNEL_ID", "1")
 os.environ.setdefault("TURSO_DATABASE_URL", ":memory:")
@@ -42,6 +44,13 @@ class AIRequestTests(unittest.IsolatedAsyncioTestCase):
             params = await ai_module.request_params("tldr")
 
         self.assertIsNone(params.extra_body)
+
+    async def test_provider_speaks_chat_completions(self):
+        # OpenRouter's Responses endpoint rejects audio/* parts, breaking /tr.
+        self.addCleanup(ai_module.close_ai_provider)
+        provider = ai_module.openrouter_provider()
+
+        self.assertIsInstance(provider.protocol, OpenAIChatCompletionsProtocol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`/tr` has been dead since #334. Prod (`superseriousbot-ssgbot-1` on oracle-mumbai) logs:

```
ValueError: Unsupported media type for OpenAI Responses: audio/wav
  ai/providers/openai/protocol.py:991 _file_part_to_responses
```

The user only ever saw "Transcription failed. Please try again."

## Cause

`ai.get_provider("openai", ...)` picks a protocol by **provider name**, not base URL — and `"openai"` defaults to the Responses protocol. We point it at OpenRouter, which is a Chat Completions API. The Responses part converter handles `image/*`, `application/pdf` and `text/*` but not `audio/*`, so the request never left the process. The Chat Completions converter does handle it, emitting the `input_audio` block the pre-#334 code sent by hand.

## Fix

Pass `protocol=OpenAIChatCompletionsProtocol()` when building the provider.

## Verification

Live against OpenRouter through `generate_text` / `generate_object`:

| path | before | after |
| --- | --- | --- |
| `tr` audio | ValueError | transcribes |
| `ask` + native web search | ok | ok |
| `song` structured output | ok | ok |
| `tldr` | ok | ok |

Web search was the one thing at risk in the switch; it works on both protocols, so nothing from #334 regresses. 89 tests pass, including a new `test_provider_speaks_chat_completions` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)