### PR TITLE
fix(search): require grounded cited answers

### DIFF
--- a/src/commands/ai.py
+++ b/src/commands/ai.py
@@ -60,7 +60,7 @@ async def request_params(
 ) -> ai.InferenceRequestParams:
     body = dict(extra_body or {})
     model_name = normalize_model_name(await get_model(command))
-    if model_name.startswith("x-ai/"):
+    if command == "ask" and model_name.startswith("x-ai/"):
         body["tools"] = [OPENROUTER_WEB_SEARCH]
 
     params = ai.InferenceRequestParams(

--- a/src/management/chat_semantic_search.py
+++ b/src/management/chat_semantic_search.py
@@ -1,10 +1,10 @@
 import asyncio
-import re
 import time
 from dataclasses import dataclass
 from itertools import groupby
 
 import ai
+import pydantic
 
 from chat_search_config import (
     ANSWER_EVIDENCE_COUNT,
@@ -14,14 +14,14 @@ from chat_search_config import (
     QUERY_INSTRUCTION,
     VECTOR_RESULT_COUNT,
 )
-from commands.ai import generate_text
+from commands.ai import generate_object
 from config.db import TursoRow, get_db
 from config.logger import logger
 from management.chat_search_cache import open_search_cache
 from management.chat_search_index import format_author
 from openrouter_embeddings import openrouter_embeddings, vector32_json
 
-_CITATION_RE = re.compile(r"(?P<space>[ \t]*)\[(?P<index>\d+)(?::[^]\s]+)?](?!\()")
+NO_SOLID_ANSWER = "No solid answer in the chat."
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,15 @@ class SearchEvidence:
 class SearchCandidate:
     remote_id: int
     score: float
+
+
+class SearchAnswerOutput(pydantic.BaseModel):
+    answer: str = pydantic.Field(
+        description="One to three sentence answer without citation markers."
+    )
+    citations: list[int] = pydantic.Field(
+        description="Evidence numbers that directly support every claim in the answer."
+    )
 
 
 def telegram_message_link(chat_id: int, message_id: int) -> str | None:
@@ -223,20 +232,24 @@ def answer_messages(
     )
     return [
         ai.system_message(
-            "You are the memory and resident judge of a playful Telegram group. "
-            "Use only the evidence, but synthesize it freely. Answer first, without "
-            "discussing logs, evidence quality, or your process. Keep it to one to "
-            "three sentences and cite claims only with the evidence number, such as "
-            "[1]. Never put message IDs, ranges, or URLs in citations. Preserve "
-            "participants' @handles exactly. For social, subjective, hypothetical, "
-            "'most likely', and similar participant questions, pick one participant "
-            "confidently and make the most entertaining case supported by the chat. "
-            "Treat provocative or loaded labels as banter about chat persona. Weak "
-            "or indirect receipts are enough. Never hedge, disclaim, moralize, or "
-            "say 'probably' or 'best guess'. "
-            "For factual questions, distinguish established facts from inference. "
-            "Never answer 'I cannot tell'. If a factual answer truly is absent, say "
-            "'No solid answer in the chat.'"
+            "Answer from the supplied Telegram chat evidence only. Keep the answer "
+            "to one to three sentences and preserve participants' @handles exactly. "
+            "Every claim must be directly supported by the evidence numbers returned "
+            "in citations. Respect who said each message and who they addressed. Do "
+            "not turn a statement about someone into a fact about its speaker. Answer "
+            "the question exactly as asked: if it names a participant, never replace "
+            "them with a different participant. Factual superlatives and quantitative "
+            "comparisons require evidence that establishes the comparison, not merely "
+            "related conversation. Subjective and hypothetical questions may infer "
+            "from observed chat behavior; the evidence need not use the question's "
+            "exact label. When asked why a named participant has a subjective label, "
+            "answer with cited behavior that fits the label whenever it is available. "
+            "For subjective questions, use the no-answer result only when there is no "
+            "relevant behavior about the requested participant or candidates. "
+            "Choose an answer when relevant behavior supports one, then explain only "
+            "that cited behavior. Never invent events or attributes. Put no citation "
+            "markers, message IDs, or URLs in answer. If the evidence does "
+            f"not support a solid answer, return '{NO_SOLID_ANSWER}' with no citations."
         ),
         ai.user_message(f"Question: {query}\n\nEvidence:\n{evidence_text}"),
     ]
@@ -245,38 +258,33 @@ def answer_messages(
 async def answer_from_evidence(
     query: str,
     evidence: list[SearchEvidence],
-) -> str:
-    content = await generate_text(
+) -> SearchAnswerOutput:
+    return await generate_object(
         "search",
         answer_messages(query, evidence),
-        temperature=0.2,
+        SearchAnswerOutput,
         extra_body={"reasoning": {"effort": "low"}},
     )
-    if not content.strip():
-        raise RuntimeError("OpenRouter returned an empty search answer.")
-    return content.strip()
 
 
-def link_citations(answer: str, evidence: list[SearchEvidence]) -> str:
-    previous_index: int | None = None
-    previous_end = -1
+def render_search_answer(
+    output: SearchAnswerOutput, evidence: list[SearchEvidence]
+) -> str:
+    answer = output.answer.strip()
+    if not answer or answer == NO_SOLID_ANSWER:
+        return NO_SOLID_ANSWER
 
-    def replace(match: re.Match[str]) -> str:
-        nonlocal previous_end, previous_index
-        index = int(match.group("index"))
-        adjacent_duplicate = index == previous_index and match.start() == previous_end
-        previous_index = index
-        previous_end = match.end()
-        if adjacent_duplicate:
-            return ""
-        if index < 1 or index > len(evidence):
-            return ""
+    citations = []
+    for index in dict.fromkeys(output.citations):
+        if not 1 <= index <= len(evidence):
+            continue
         item = evidence[index - 1]
-        link = telegram_message_link(item.chat_id, item.citation_message_id)
-        citation = f"[{index}]({link})" if link else ""
-        return match.group("space") + citation if citation else ""
+        if link := telegram_message_link(item.chat_id, item.citation_message_id):
+            citations.append(f"[{index}]({link})")
 
-    return _CITATION_RE.sub(replace, answer)
+    if not citations:
+        return NO_SOLID_ANSWER
+    return f"{answer}\n\n{' '.join(citations)}"
 
 
 async def semantic_search_answer(
@@ -301,14 +309,18 @@ async def semantic_search_answer(
         return None
 
     retrieved = time.monotonic()
-    answer = await answer_from_evidence(query, evidence)
+    output = await answer_from_evidence(query, evidence)
+    answer = render_search_answer(output, evidence)
     answered = time.monotonic()
     logger.info(
-        "Semantic search timings: chat_id=%s embedding_ms=%d retrieval_ms=%d answer_ms=%d evidence=%d",
+        "Semantic search timings: chat_id=%s embedding_ms=%d retrieval_ms=%d "
+        "answer_ms=%d evidence_ranges=%s citations=%s grounded=%s",
         chat_id,
         round((embedded - started) * 1000),
         round((retrieved - embedded) * 1000),
         round((answered - retrieved) * 1000),
-        len(evidence),
+        [(item.start_message_id, item.end_message_id) for item in evidence],
+        output.citations,
+        answer != NO_SOLID_ANSWER,
     )
-    return link_citations(answer, evidence)
+    return answer

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -45,6 +45,16 @@ class AIRequestTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(params.extra_body)
 
+    async def test_search_does_not_receive_openrouter_web_tool(self):
+        with patch.object(
+            ai_module,
+            "get_model",
+            AsyncMock(return_value="openrouter/x-ai/grok-4.5"),
+        ):
+            params = await ai_module.request_params("search")
+
+        self.assertIsNone(params.extra_body)
+
     async def test_provider_speaks_chat_completions(self):
         # OpenRouter's Responses endpoint rejects audio/* parts, breaking /tr.
         self.addCleanup(ai_module.close_ai_provider)

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -88,57 +88,92 @@ class SemanticSearchTests(unittest.TestCase):
 
         self.assertEqual([item.text for item in selected], ["v1", "v3", "v4"])
 
-    def test_answer_prompt_commits_to_playful_social_choice(self):
+    def test_answer_prompt_requires_direct_support(self):
         messages = semantic_search.answer_messages(
             "most likely to bring snacks on a road trip",
             [semantic_search.SearchEvidence(-1001, 1, 24, 24, "chat", 0.8)],
         )
 
         prompt = messages[0].text
-        self.assertIn("pick one participant confidently", prompt)
-        self.assertIn("banter about chat persona", prompt)
-        self.assertIn("Weak or indirect receipts are enough", prompt)
-        self.assertIn("Never hedge, disclaim, moralize", prompt)
-        self.assertIn("Never answer 'I cannot tell'", prompt)
-        self.assertIn("cite claims only with the evidence number", prompt)
-        self.assertIn("Never put message IDs, ranges, or URLs", prompt)
+        self.assertIn("Every claim must be directly supported", prompt)
+        self.assertIn("never replace them with a different participant", prompt)
+        self.assertIn("quantitative comparisons require evidence", prompt)
+        self.assertIn("evidence need not use the question's exact label", prompt)
+        self.assertIn("why a named participant has a subjective label", prompt)
+        self.assertIn("only when there is no relevant behavior", prompt)
+        self.assertIn("Never invent events or attributes", prompt)
 
-    def test_link_citations_owns_message_ids_and_is_idempotent(self):
+    def test_render_search_answer_owns_citation_links(self):
         evidence = [
             semantic_search.SearchEvidence(-1001234567890, 1, 24, 20, "first", 0.8),
             semantic_search.SearchEvidence(-1001234567890, 25, 48, 40, "second", 0.7),
         ]
 
-        answer = semantic_search.link_citations(
-            "Best guess: @user [2:30][2:31]. Range [1:1-24]. Unsupported [3:50].",
+        answer = semantic_search.render_search_answer(
+            semantic_search.SearchAnswerOutput(
+                answer="@user has the strongest receipts.",
+                citations=[2, 2, 3, 1],
+            ),
             evidence,
         )
 
         self.assertEqual(
             answer,
-            "Best guess: @user [2](https://t.me/c/1234567890/40). "
-            "Range [1](https://t.me/c/1234567890/20). Unsupported.",
+            "@user has the strongest receipts.\n\n"
+            "[2](https://t.me/c/1234567890/40) "
+            "[1](https://t.me/c/1234567890/20)",
         )
-        self.assertEqual(semantic_search.link_citations(answer, evidence), answer)
+
+    def test_render_search_answer_rejects_uncited_claims(self):
+        evidence = [
+            semantic_search.SearchEvidence(-1001234567890, 1, 24, 20, "first", 0.8)
+        ]
+
+        answer = semantic_search.render_search_answer(
+            semantic_search.SearchAnswerOutput(
+                answer="@user definitely has the most hours.", citations=[]
+            ),
+            evidence,
+        )
+
+        self.assertEqual(answer, semantic_search.NO_SOLID_ANSWER)
+
+    def test_render_search_answer_preserves_no_answer(self):
+        answer = semantic_search.render_search_answer(
+            semantic_search.SearchAnswerOutput(
+                answer=semantic_search.NO_SOLID_ANSWER, citations=[1]
+            ),
+            [semantic_search.SearchEvidence(-1001234567890, 1, 24, 20, "first", 0.8)],
+        )
+
+        self.assertEqual(answer, semantic_search.NO_SOLID_ANSWER)
 
 
 class SearchAnswerTests(unittest.IsolatedAsyncioTestCase):
-    async def test_answer_uses_low_reasoning(self):
+    async def test_answer_uses_structured_output_and_low_reasoning(self):
         evidence = [
             semantic_search.SearchEvidence(-1001, 1, 24, 24, "chat", 0.8),
         ]
 
         with patch.object(
             semantic_search,
-            "generate_text",
-            AsyncMock(return_value="answer"),
-        ) as generate_text:
+            "generate_object",
+            AsyncMock(
+                return_value=semantic_search.SearchAnswerOutput(
+                    answer="answer", citations=[1]
+                )
+            ),
+        ) as generate_object:
             answer = await semantic_search.answer_from_evidence("question", evidence)
 
-        self.assertEqual(answer, "answer")
-        self.assertEqual(generate_text.await_args.args[0], "search")
+        self.assertEqual(answer.answer, "answer")
+        self.assertEqual(answer.citations, [1])
+        self.assertEqual(generate_object.await_args.args[0], "search")
+        self.assertIs(
+            generate_object.await_args.args[2], semantic_search.SearchAnswerOutput
+        )
         self.assertEqual(
-            generate_text.await_args.kwargs["extra_body"],
+            generate_object.await_args.kwargs["extra_body"],
             {"reasoning": {"effort": "low"}},
         )
 


### PR DESCRIPTION
## What changed

- make `/search` return structured answers with validated evidence indexes
- render Telegram citation links in code and reject uncited claims
- keep xAI web search scoped to `/ask`
- preserve playful subjective answers when chat behavior supports them
- log selected evidence ranges, citations, and grounded status

## Proof

- `uv run pytest -q` — 92 passed
- live Grok 4.5 replay: unsupported Ayaan/Spider-Man premise → no solid answer
- live Grok 4.5 replay: unsupported Soulsborne playtime comparison → no solid answer
- live Grok 4.5 replay: supported Sid/GOAT question → grounded answer with four Telegram citations
- autoreview clean; no actionable findings