### PR TITLE
feat(dl): support Instagram image posts

### DIFF
--- a/src/commands/dl.py
+++ b/src/commands/dl.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+from html.parser import HTMLParser
 from urllib.parse import ParseResult, urlparse
 
 import aiohttp
@@ -40,6 +41,24 @@ def _is_instagram_reel(url: ParseResult) -> bool:
     return host in {"instagram.com", "www.instagram.com"} and url.path.startswith(
         "/reel/"
     )
+
+
+def _is_instagram_post(url: ParseResult) -> bool:
+    host = url.hostname or ""
+    return host in {"instagram.com", "www.instagram.com"} and url.path.startswith("/p/")
+
+
+class InstagramImageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.image_url: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "meta" or self.image_url:
+            return
+        attributes = dict(attrs)
+        if attributes.get("property") == "og:image":
+            self.image_url = attributes.get("content")
 
 
 async def _is_auto_dl_enabled(chat_id: int) -> bool:
@@ -114,6 +133,29 @@ async def _fetch_with_yt_dlp(
     await _fetch_and_send(message, session, media_url, filename)
 
 
+async def _fetch_instagram_image(
+    message: Message,
+    session: aiohttp.ClientSession,
+    target: str,
+) -> None:
+    async with session.get(
+        target,
+        headers={"User-Agent": "Mozilla/5.0"},
+        timeout=MEDIA_TIMEOUT,
+    ) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Instagram page fetch failed: {resp.status}")
+        parser = InstagramImageParser()
+        parser.feed(await resp.text())
+
+    if not parser.image_url:
+        raise RuntimeError("Instagram post has no image metadata")
+    shortcode = urlparse(target).path.rstrip("/").rsplit("/", 1)[-1]
+    await _fetch_and_send(
+        message, session, parser.image_url, f"instagram_{shortcode}.jpg"
+    )
+
+
 async def _fetch_and_send(
     message: Message,
     session: aiohttp.ClientSession,
@@ -184,11 +226,19 @@ async def _download_media(message: Message, url: ParseResult) -> None:
             try:
                 data = await _request_cobalt(session, endpoint, target)
             except (aiohttp.ClientError, RuntimeError, TimeoutError) as e:
-                if not _is_instagram_reel(url):
-                    raise
-                logger.warning("Cobalt failed for Instagram Reel; using yt-dlp: %s", e)
-                await _fetch_with_yt_dlp(message, session, target)
-                return
+                if _is_instagram_reel(url):
+                    logger.warning(
+                        "Cobalt failed for Instagram Reel; using yt-dlp: %s", e
+                    )
+                    await _fetch_with_yt_dlp(message, session, target)
+                    return
+                if _is_instagram_post(url):
+                    logger.warning(
+                        "Cobalt failed for Instagram post; using page metadata: %s", e
+                    )
+                    await _fetch_instagram_image(message, session, target)
+                    return
+                raise
 
             if _needs_yt_dlp(url, data):
                 logger.info(
@@ -243,6 +293,9 @@ async def _download_media(message: Message, url: ParseResult) -> None:
                 return
 
             if status == "error":
+                if _is_instagram_post(url):
+                    await _fetch_instagram_image(message, session, target)
+                    return
                 err = data.get("error", {})
                 await message.reply_text(
                     f"Failed to fetch media: {err.get('code') or 'unknown'}"

--- a/tests/test_dl.py
+++ b/tests/test_dl.py
@@ -27,6 +27,39 @@ class SessionContext:
 
 
 class DownloadTests(IsolatedAsyncioTestCase):
+    async def test_instagram_post_cobalt_error_uses_page_image(self) -> None:
+        message = SimpleNamespace(reply_text=AsyncMock())
+        url = urlparse("https://www.instagram.com/p/DbW6GhitktH/")
+        session = SessionContext()
+
+        with (
+            patch.object(dl.config.API, "COBALT_URL", "http://cobalt/"),
+            patch.object(dl.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                dl,
+                "_request_cobalt",
+                AsyncMock(
+                    return_value={
+                        "status": "error",
+                        "error": {"code": "error.api.fetch.empty"},
+                    }
+                ),
+            ),
+            patch.object(dl, "_fetch_instagram_image", AsyncMock()) as fallback,
+        ):
+            await dl._download_media(message, url)
+
+        fallback.assert_awaited_once_with(message, session.session, url.geturl())
+        message.reply_text.assert_not_awaited()
+
+    async def test_instagram_image_parser_reads_og_image(self) -> None:
+        parser = dl.InstagramImageParser()
+        parser.feed(
+            '<meta property="og:image" content="https://cdn.example/image.jpg?a=1&amp;b=2">'
+        )
+
+        self.assertEqual(parser.image_url, "https://cdn.example/image.jpg?a=1&b=2")
+
     async def test_instagram_reel_image_falls_back_to_yt_dlp(self) -> None:
         message = SimpleNamespace(reply_text=AsyncMock())
         url = urlparse("https://www.instagram.com/reel/DbT2vSHtvXs/")


### PR DESCRIPTION
## Summary
- fall back to Instagram page metadata when Cobalt cannot fetch image posts
- send the extracted image through the existing media path

## Validation
- `uv run pytest tests/test_dl.py`
- `uv run ruff check src/commands/dl.py tests/test_dl.py`
- `uv run ty check`