### PR TITLE
fix(tr): send long transcripts as a document

### DIFF
--- a/src/commands/transcribe.py
+++ b/src/commands/transcribe.py
@@ -16,7 +16,7 @@ from config.logger import logger
 from config.options import config
 from utils.command_limits import ensure_quota
 from utils.decorators import command
-from utils.messages import get_message
+from utils.messages import get_message, reply_markdown_or_plain
 
 FALLBACK_PROMPT = "Please transcribe this audio file. No wall of text, keep it readable, suitable for a Telegram message. Begin transcript immediately without any commentary."
 
@@ -157,4 +157,9 @@ async def transcribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await message.reply_text("No transcript was returned. Please try again.")
         return
 
-    await message.reply_text(transcript, disable_web_page_preview=True)
+    await reply_markdown_or_plain(
+        message,
+        transcript,
+        disable_web_page_preview=True,
+        document_name="transcript.txt",
+    )


### PR DESCRIPTION
## Problem

`/tr` still fails on prod, but for a new reason — #335 fixed the wire protocol, and the model now transcribes fine:

```
command=tr status=failed duration_ms=62106 error_type=BadRequest
  transcribe.py:160 await message.reply_text(transcript, ...)
telegram.error.BadRequest: Message is too long
```

Zero `Unsupported media type` errors since the #335 deploy, so that fix holds. This is the next failure in line: a long voice note transcribes past Telegram's 4096-character limit, `reply_text` throws, and the user gets nothing back at all — the worst outcome, since the transcript existed and we threw it away.

## Fix

Send the transcript through `reply_markdown_or_plain` with `document_name="transcript.txt"`. That helper already backs `/ask`, `/tldr` and `/search`: markdown when it fits, plain text when markdown fails, `.txt` document when it's too long. `/tr` was the one AI command still calling `reply_text` directly.

89 tests pass; `test_reply_markdown_or_plain_defaults_document_for_long_text` already covers the document fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)