### PR TITLE
feat(tldr): summarize replied text documents

### DIFF
--- a/src/commands/tldr.py
+++ b/src/commands/tldr.py
@@ -2,9 +2,10 @@ import html
 from urllib.parse import parse_qs, urlparse
 
 import ai
-from telegram import Update
+from telegram import Document, Update
 from telegram.constants import ParseMode
-from telegram.ext import ContextTypes
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes, ExtBot
 
 import commands
 import utils
@@ -16,6 +17,18 @@ from config.options import config
 from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message, reply_markdown_or_plain
+
+MAX_DOCUMENT_BYTES = 2_000_000
+
+
+async def read_text_document(bot: ExtBot, document: Document) -> str | None:
+    """Return a document's contents as text, or None if it isn't text."""
+    telegram_file = await bot.getFile(document.file_id)
+    data = bytes(await telegram_file.download_as_bytearray())
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
 
 
 def extract_youtube_video_id(url: str) -> str | None:
@@ -74,11 +87,11 @@ Rules:
     triggers=["tldr", "tldw"],
     usage="/tldr",
     example="/tldr",
-    description="Generate a TLDR summary. Works with YouTube videos, URLs, or replied message text.",
+    description="Generate a TLDR summary. Works with YouTube videos, URLs, replied message text, or text files.",
     api_key="OPENROUTER_API_KEY",
 )
-async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
-    """Generate a TLDR for YouTube videos, URLs, or replied text."""
+async def tldr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Generate a TLDR for YouTube videos, URLs, replied text, or text files."""
     import aiohttp
 
     message = get_message(update)
@@ -210,21 +223,46 @@ async def tldr(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
             return
     else:
         source_message = message.reply_to_message
-        if not source_message or not (
-            getattr(source_message, "text", None)
-            or getattr(source_message, "caption", None)
-        ):
+        if not source_message:
             await commands.usage_string(message, tldr)
             return
-        raw_text = source_message.text or source_message.caption or ""
+
         username = (
             source_message.from_user.username if source_message.from_user else "unknown"
         )
-        summary_prompt = (
-            f"Please create a TLDR summary of this message from {username}:"
-        )
         response_suffix = ""
-        error_subject = "replied message"
+
+        if document := source_message.document:
+            if (document.file_size or 0) > MAX_DOCUMENT_BYTES:
+                await message.reply_text("That file is too big to summarize.")
+                return
+            try:
+                file_text = await read_text_document(context.bot, document)
+            except TelegramError as e:
+                logger.error("Error downloading %s: %s", document.file_name, e)
+                await message.reply_text("I couldn't download that file.")
+                return
+            if file_text is None:
+                await message.reply_text("I can only summarize text files.")
+                return
+            if not file_text.strip():
+                await message.reply_text("That file is empty.")
+                return
+            raw_text = file_text
+            summary_prompt = (
+                f"Please create a TLDR summary of this file "
+                f"named {document.file_name} shared by {username}:"
+            )
+            error_subject = "document"
+        elif source_message.text or source_message.caption:
+            raw_text = source_message.text or source_message.caption or ""
+            summary_prompt = (
+                f"Please create a TLDR summary of this message from {username}:"
+            )
+            error_subject = "replied message"
+        else:
+            await commands.usage_string(message, tldr)
+            return
 
     try:
         if len(raw_text) > 20000:

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -29,6 +29,7 @@ habit_module = importlib.import_module("commands.habit")
 meme_module = importlib.import_module("commands.meme")
 model_module = importlib.import_module("commands.model")
 song_module = importlib.import_module("commands.song")
+tldr_module = importlib.import_module("commands.tldr")
 transcribe_module = importlib.import_module("commands.transcribe")
 weather_module = importlib.import_module("commands.weather")
 messages_module = importlib.import_module("utils.messages")
@@ -335,6 +336,101 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
             await transcribe_module.transcribe(update, context)
 
         self.assertEqual(message.replies, ["Transcription is not configured."])
+
+    async def test_read_text_document_decodes_utf8_only(self):
+        class FakeFile:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+            async def download_as_bytearray(self) -> bytearray:
+                return bytearray(self.data)
+
+        class FileBot:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+            async def getFile(self, _file_id):
+                return FakeFile(self.data)
+
+        document = SimpleNamespace(file_id="doc-file")
+
+        self.assertEqual(
+            await tldr_module.read_text_document(
+                FileBot("héllo transcript".encode()), document
+            ),
+            "héllo transcript",
+        )
+        self.assertIsNone(
+            await tldr_module.read_text_document(
+                FileBot(b"\x89PNG\r\n\x1a\n\xff\xfe"), document
+            )
+        )
+
+    async def test_tldr_summarizes_a_replied_text_document(self):
+        message = FakeMessage()
+        message.reply_to_message = SimpleNamespace(
+            document=SimpleNamespace(
+                file_id="doc-file", file_name="transcript.txt", file_size=42
+            ),
+            text=None,
+            caption=None,
+            from_user=SimpleNamespace(username="obviyus"),
+        )
+        update = SimpleNamespace(effective_user=message.from_user)
+        context = SimpleNamespace(bot=FakeBot(), args=[])
+        summarize = AsyncMock(return_value="- a point")
+
+        with (
+            patch.object(tldr_module, "get_message", return_value=message),
+            patch.object(tldr_module.utils, "extract_link", return_value=None),
+            patch.object(
+                tldr_module,
+                "ensure_command_available",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(tldr_module, "ensure_quota", AsyncMock(return_value=True)),
+            patch.object(
+                tldr_module,
+                "read_text_document",
+                AsyncMock(return_value="the whole transcript"),
+            ),
+            patch.object(tldr_module, "summarize_text", summarize),
+        ):
+            await tldr_module.tldr(update, context)
+
+        self.assertIn("the whole transcript", summarize.await_args.args[0])
+        self.assertIn("transcript.txt", summarize.await_args.args[0])
+        self.assertIn("- a point", message.replies[0])
+
+    async def test_tldr_rejects_a_replied_binary_document(self):
+        message = FakeMessage()
+        message.reply_to_message = SimpleNamespace(
+            document=SimpleNamespace(
+                file_id="doc-file", file_name="cat.png", file_size=42
+            ),
+            text=None,
+            caption=None,
+            from_user=SimpleNamespace(username="obviyus"),
+        )
+        update = SimpleNamespace(effective_user=message.from_user)
+        context = SimpleNamespace(bot=FakeBot(), args=[])
+
+        with (
+            patch.object(tldr_module, "get_message", return_value=message),
+            patch.object(tldr_module.utils, "extract_link", return_value=None),
+            patch.object(
+                tldr_module,
+                "ensure_command_available",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(tldr_module, "ensure_quota", AsyncMock(return_value=True)),
+            patch.object(
+                tldr_module, "read_text_document", AsyncMock(return_value=None)
+            ),
+        ):
+            await tldr_module.tldr(update, context)
+
+        self.assertEqual(message.replies, ["I can only summarize text files."])
 
     async def test_weather_missing_keys_uses_user_facing_message(self):
         message = FakeMessage()


### PR DESCRIPTION
## Why

#338 made `/tr` answer long voice notes with a `transcript.txt` document. `/tldr` only read message text and captions, so there was no way to summarize the file the bot had just sent — the two commands didn't compose.

## What

Reply `/tldr` to any text document and it summarizes the file.

- **Text is decided by decoding, not by mime type.** Desktop clients routinely label `.txt` as `application/octet-stream`, so a mime allowlist would reject real text files. If the bytes decode as UTF-8 it's text; if not, the user gets "I can only summarize text files." One rule, no format table to maintain.
- Downloads capped at 2 MB. The existing 20k-character truncation still bounds what reaches the model.
- Empty file and failed download each get their own message rather than an empty summary.

The document branch produces the same `raw_text` / `summary_prompt` / `error_subject` triple as the URL and replied-text branches, so it joins the existing flow instead of forking it.

## Tests

97 pass. New: document routing, binary rejection, and a direct `read_text_document` check covering both the UTF-8 and non-UTF-8 outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)