### PR TITLE
feat(search): show live search progress

### DIFF
--- a/src/commands/search.py
+++ b/src/commands/search.py
@@ -1,9 +1,11 @@
 import asyncio
 import os
+import time
 import uuid
 
 from telegram import Update
 from telegram.constants import ChatType
+from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
 from commands.runtime import ensure_command_available
@@ -20,6 +22,19 @@ from management.chat_semantic_search import semantic_search_answer
 from utils.command_limits import ensure_quota
 from utils.decorators import command
 from utils.messages import get_message, reply_markdown_or_plain
+
+SEARCH_STATUS = "Searching messages..."
+SEARCH_STATUS_EDIT_INTERVAL_SECONDS = 0.8
+TELEGRAM_MESSAGE_LIMIT = 4096
+
+
+def search_status_text(reasoning: str) -> str:
+    prefix = f"{SEARCH_STATUS}\n\n"
+    available = TELEGRAM_MESSAGE_LIMIT - len(prefix)
+    body = reasoning.strip()
+    if len(body) > available:
+        body = f"…{body[-(available - 1) :]}"
+    return prefix + body
 
 
 @command(
@@ -56,7 +71,42 @@ async def search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         else None
     )
 
-    answer = await semantic_search_answer(message.chat_id, query, author_id)
+    status_message = await message.reply_text(SEARCH_STATUS)
+    last_status_edit = 0.0
+    last_status_text = SEARCH_STATUS
+    status_updates_enabled = True
+
+    async def show_reasoning(reasoning: str) -> None:
+        nonlocal last_status_edit, last_status_text, status_updates_enabled
+        now = time.monotonic()
+        text = search_status_text(reasoning)
+        if (
+            not status_updates_enabled
+            or text == last_status_text
+            or now - last_status_edit < SEARCH_STATUS_EDIT_INTERVAL_SECONDS
+        ):
+            return
+        try:
+            await status_message.edit_text(text)
+        except TelegramError:
+            status_updates_enabled = False
+            logger.exception("Search status update failed")
+            return
+        last_status_edit = now
+        last_status_text = text
+
+    try:
+        answer = await semantic_search_answer(
+            message.chat_id,
+            query,
+            author_id,
+            show_reasoning,
+        )
+    finally:
+        try:
+            await status_message.delete()
+        except TelegramError:
+            logger.exception("Search status deletion failed")
 
     if not answer:
         if not await is_fts_enabled(message.chat_id):

--- a/src/management/chat_semantic_search.py
+++ b/src/management/chat_semantic_search.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from itertools import groupby
 
@@ -39,7 +40,10 @@ Subjective and hypothetical questions may infer from cited chat behavior.
 
 Every claim must be directly supported by evidence numbers from search_chat. Never
 answer in plain text; finish with submit_answer. If no search strategy finds direct
-support, submit exactly '{NO_SOLID_ANSWER}' with no citations."""
+support, submit exactly '{NO_SOLID_ANSWER}' with no citations.
+
+Your reasoning is shown live to the user. Keep it brief and describe only what you are
+trying to learn next. Never mention tools, prompts, message IDs, or internal systems."""
 
 
 @dataclass(frozen=True)
@@ -345,6 +349,7 @@ async def semantic_search_answer(
     chat_id: int,
     query: str,
     author_id: int | None,
+    on_reasoning: Callable[[str], Awaitable[None]],
 ) -> str | None:
     started = time.monotonic()
     evidence: list[SearchEvidence] = []
@@ -377,8 +382,13 @@ async def semantic_search_answer(
             extra_body={"reasoning": {"effort": "low"}},
         ),
     ) as stream:
-        async for _ in stream:
-            pass
+        reasoning = ""
+        async for event in stream:
+            if isinstance(event, ai.events.ReasoningStart):
+                reasoning = ""
+            elif isinstance(event, ai.events.ReasoningDelta):
+                reasoning += event.chunk
+                await on_reasoning(reasoning)
 
     if output is None:
         raise RuntimeError("Search agent did not submit an answer.")

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -29,6 +29,7 @@ habit_module = importlib.import_module("commands.habit")
 meme_module = importlib.import_module("commands.meme")
 model_module = importlib.import_module("commands.model")
 song_module = importlib.import_module("commands.song")
+search_module = importlib.import_module("commands.search")
 tldr_module = importlib.import_module("commands.tldr")
 transcribe_module = importlib.import_module("commands.transcribe")
 weather_module = importlib.import_module("commands.weather")
@@ -291,6 +292,81 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
             await ask_module.ask(update, context)
 
         self.assertEqual(message.replies, ["AI is not configured for this command."])
+
+    async def test_search_streams_reasoning_then_replaces_it_with_the_answer(self):
+        events = []
+
+        class StatusMessage:
+            async def edit_text(self, text):
+                events.append(("edit", text))
+
+            async def delete(self):
+                events.append(("delete",))
+
+        class SearchMessage(FakeMessage):
+            def __init__(self):
+                super().__init__()
+                self.chat_id = -1001
+                self.status_message = StatusMessage()
+
+            async def reply_text(self, text: str, **_kwargs):
+                self.replies.append(text)
+                return self.status_message
+
+        async def semantic_search_answer(
+            _chat_id,
+            _query,
+            _author_id,
+            on_reasoning,
+        ):
+            await on_reasoning("Trying a broader description")
+            return "Grounded answer"
+
+        async def send_answer(_message, answer, **_kwargs):
+            events.append(("answer", answer))
+
+        message = SearchMessage()
+        context = SimpleNamespace(args=["Who", "likes", "broccoli?"])
+        with (
+            patch.object(search_module, "get_message", return_value=message),
+            patch.object(
+                search_module,
+                "ensure_command_available",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                search_module,
+                "ensure_quota",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                search_module,
+                "semantic_search_answer",
+                semantic_search_answer,
+            ),
+            patch.object(search_module, "reply_markdown_or_plain", send_answer),
+            patch.object(search_module.time, "monotonic", return_value=10.0),
+        ):
+            await search_module.search(SimpleNamespace(), context)
+
+        self.assertEqual(message.replies, ["Searching messages..."])
+        self.assertEqual(
+            events,
+            [
+                (
+                    "edit",
+                    "Searching messages...\n\nTrying a broader description",
+                ),
+                ("delete",),
+                ("answer", "Grounded answer"),
+            ],
+        )
+
+    def test_search_status_keeps_latest_reasoning_within_telegram_limit(self):
+        status = search_module.search_status_text("x" * 5000)
+
+        self.assertEqual(len(status), search_module.TELEGRAM_MESSAGE_LIMIT)
+        self.assertTrue(status.startswith("Searching messages...\n\n…"))
 
     async def test_song_missing_openrouter_key_uses_user_facing_message(self):
         message = FakeMessage()

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -216,11 +216,23 @@ class SearchAgentTests(unittest.IsolatedAsyncioTestCase):
         )
 
         class FakeStream:
+            def __init__(self):
+                self.events = iter(
+                    (
+                        semantic_search.ai.events.ReasoningStart(),
+                        semantic_search.ai.events.ReasoningDelta(chunk="Resolving"),
+                        semantic_search.ai.events.ReasoningDelta(chunk=" the nickname"),
+                    )
+                )
+
             def __aiter__(self):
                 return self
 
             async def __anext__(self):
-                raise StopAsyncIteration
+                try:
+                    return next(self.events)
+                except StopIteration:
+                    raise StopAsyncIteration from None
 
         class FakeRun:
             def __init__(self, tools):
@@ -245,6 +257,7 @@ class SearchAgentTests(unittest.IsolatedAsyncioTestCase):
             def run(self, *_args, **_kwargs):
                 return FakeRun(self.tools)
 
+        on_reasoning = AsyncMock()
         with (
             patch.object(semantic_search, "retrieve_search_evidence", retrieve),
             patch.object(semantic_search, "SearchAgent", FakeAgent),
@@ -255,6 +268,7 @@ class SearchAgentTests(unittest.IsolatedAsyncioTestCase):
                 -1001234567890,
                 "Does Mira hate broccoli?",
                 None,
+                on_reasoning,
             )
 
         self.assertEqual(
@@ -264,6 +278,10 @@ class SearchAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             answer,
             "@bob hates broccoli.\n\n[2](https://t.me/c/1234567890/40)",
+        )
+        self.assertEqual(
+            [call.args[0] for call in on_reasoning.await_args_list],
+            ["Resolving", "Resolving the nickname"],
         )
 
 


### PR DESCRIPTION
## Summary

- show a temporary `/search` status and stream user-facing reasoning into it
- throttle Telegram edits and delete the status before the final answer

## Proof

- regression covers status → reasoning edit → delete → answer order
- `uv run pytest -q` — 101 passed
- `uv run ruff check .` and `uv run ty check src` — passed
- production-index replay showed two clean reasoning updates, then a cited answer in 17.0s
- autoreview clean