### PR TITLE
feat(edit): generate images from standalone prompts

### DIFF
--- a/src/commands/ask.py
+++ b/src/commands/ask.py
@@ -7,6 +7,10 @@ from datetime import timedelta
 
 import ai
 import openai
+from openai.types.chat import (
+    ChatCompletionContentPartParam,
+    ChatCompletionUserMessageParam,
+)
 from telegram import Message, Update
 from telegram.constants import ChatType
 from telegram.error import BadRequest, RetryAfter, TelegramError
@@ -282,7 +286,7 @@ async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     usage="/edit [prompt]",
     api_key="OPENROUTER_API_KEY",
     example="/edit Make it look like a painting",
-    description="Reply to an image or sticker to edit it using AI. Provide a prompt describing the desired changes.",
+    description="Generate an image from a prompt. Reply to an image or sticker to edit it instead.",
 )
 async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = get_message(update)
@@ -293,51 +297,52 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not await ensure_quota(message, message.from_user.id, "edit"):
         return
 
-    reply = message.reply_to_message
-    if not reply:
-        await commands.usage_string(message, edit)
-        return
-
     if not context.args:
-        await message.reply_text(
-            "Please provide a prompt describing how to edit the image."
-        )
+        await message.reply_text("Please provide a prompt describing the image.")
         return
 
     prompt = " ".join(context.args)
+    reply = message.reply_to_message
 
     try:
-        try:
-            reply_image = await load_reply_image(
-                reply,
-                context.bot,
-                allow_image_document=True,
+        reply_image = None
+        if reply:
+            try:
+                reply_image = await load_reply_image(
+                    reply,
+                    context.bot,
+                    allow_image_document=True,
+                )
+            except ValueError as exc:
+                await message.reply_text(str(exc))
+                return
+
+        content: list[ChatCompletionContentPartParam] = [
+            {
+                "type": "text",
+                "text": (
+                    f"Please edit this image according to the following description: {prompt}"
+                    if reply_image
+                    else f"Please generate an image according to the following description: {prompt}"
+                ),
+            }
+        ]
+        if reply_image:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": image_data_url(*reply_image)},
+                }
             )
-        except ValueError as exc:
-            await message.reply_text(str(exc))
-            return
-
-        if not reply_image:
-            await commands.usage_string(message, edit)
-            return
-
-        image_url = image_data_url(*reply_image)
 
         image_model = await model("edit")
+        user_message: ChatCompletionUserMessageParam = {
+            "role": "user",
+            "content": content,
+        }
         response = await openrouter_provider().sdk_client.chat.completions.create(
             model=image_model.id,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"Please edit this image according to the following description: {prompt}",
-                        },
-                        {"type": "image_url", "image_url": {"url": image_url}},
-                    ],
-                }
-            ],
+            messages=[user_message],
             extra_body={"modalities": ["image", "text"]},
         )
         choice = response.choices[0] if response.choices else None
@@ -381,12 +386,10 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 return
 
         if ai_message.content:
-            await message.reply_text(
-                f"{ai_message.content}\n\nNo edited image was generated."
-            )
+            await message.reply_text(f"{ai_message.content}\n\nNo image was generated.")
             return
 
-        await message.reply_text("Could not generate edited image. Please try again.")
+        await message.reply_text("Could not generate image. Please try again.")
 
     except (openai.OpenAIError, TelegramError, TimeoutError, TypeError, ValueError):
         logger.exception("Edit command failed")

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import base64
 import importlib
 import io
 import json
@@ -293,6 +294,91 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
             await ask_module.ask(update, context)
 
         self.assertEqual(message.replies, ["AI is not configured for this command."])
+
+    async def test_edit_generates_without_a_reply_and_edits_replied_images(self):
+        generated_image = base64.b64encode(b"generated-image").decode()
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        model_extra={
+                            "images": [
+                                {
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{generated_image}"
+                                    }
+                                }
+                            ]
+                        },
+                        content=None,
+                    ),
+                )
+            ]
+        )
+        create_completion = AsyncMock(return_value=response)
+        provider = SimpleNamespace(
+            sdk_client=SimpleNamespace(
+                chat=SimpleNamespace(
+                    completions=SimpleNamespace(create=create_completion)
+                )
+            )
+        )
+        context = SimpleNamespace(args=["A", "tiny", "moon"], bot=object())
+
+        with (
+            patch.object(
+                ask_module,
+                "ensure_command_available",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(ask_module, "ensure_quota", AsyncMock(return_value=True)),
+            patch.object(
+                ask_module,
+                "model",
+                AsyncMock(return_value=SimpleNamespace(id="image-model")),
+            ),
+            patch.object(ask_module, "openrouter_provider", return_value=provider),
+            patch.object(
+                ask_module,
+                "load_reply_image",
+                AsyncMock(return_value=(b"source-image", "image/png")),
+            ) as load_reply_image,
+        ):
+            generate_message = FakeMessage()
+            generate_message.from_user.username = "tester"
+            with patch.object(ask_module, "get_message", return_value=generate_message):
+                await ask_module.edit(
+                    SimpleNamespace(effective_user=generate_message.from_user), context
+                )
+
+            edit_message = FakeMessage()
+            edit_message.from_user.username = "tester"
+            edit_message.reply_to_message = object()
+            with patch.object(ask_module, "get_message", return_value=edit_message):
+                await ask_module.edit(
+                    SimpleNamespace(effective_user=edit_message.from_user), context
+                )
+
+        generated_content = create_completion.await_args_list[0].kwargs["messages"][0][
+            "content"
+        ]
+        edited_content = create_completion.await_args_list[1].kwargs["messages"][0][
+            "content"
+        ]
+        self.assertEqual(
+            generated_content,
+            [
+                {
+                    "type": "text",
+                    "text": "Please generate an image according to the following description: A tiny moon",
+                }
+            ],
+        )
+        self.assertEqual(edited_content[1]["type"], "image_url")
+        self.assertEqual(load_reply_image.await_count, 1)
+        self.assertEqual(len(generate_message.photos), 1)
+        self.assertEqual(len(edit_message.photos), 1)
 
     async def test_search_streams_reasoning_then_replaces_it_with_the_answer(self):
         events = []


### PR DESCRIPTION
## Summary

- Generate an image when `/edit` receives a prompt without a replied image.
- Preserve image editing when `/edit` replies to an image or sticker.

## Validation

- `uv run pytest -q`
- `uv run ruff check src/commands/ask.py tests/test_command_regressions.py`
- `uv run ty check`