### PR TITLE
fix(edit): explain moderation rejection

### DIFF
--- a/src/commands/ask.py
+++ b/src/commands/ask.py
@@ -44,7 +44,17 @@ def image_data_url(image_data: bytes, mime_type: str | None) -> str:
 
 
 class OpenRouterImageError(RuntimeError):
-    pass
+    def __init__(self, status: int, detail: str | None) -> None:
+        diagnostic = f"OpenRouter image rejected status={status}"
+        if detail:
+            diagnostic += f" detail={detail}"
+        super().__init__(diagnostic)
+        self.user_message = (
+            "The generated image was rejected by content moderation. "
+            "Try a different prompt or source image."
+            if detail == "Generated image rejected by content moderation."
+            else "AI request failed. Please try again."
+        )
 
 
 def build_image_request(
@@ -80,10 +90,7 @@ async def image_rejection(response: aiohttp.ClientResponse) -> OpenRouterImageEr
     detail = " ".join(message.split()) if isinstance(message, str) else None
     if detail and (len(detail) > 300 or "base64" in detail.lower()):
         detail = None
-    diagnostic = f"OpenRouter image rejected status={response.status}"
-    if detail:
-        diagnostic += f" detail={detail}"
-    return OpenRouterImageError(diagnostic)
+    return OpenRouterImageError(response.status, detail)
 
 
 async def generate_image(request: dict[str, object]) -> bytes:
@@ -363,9 +370,12 @@ async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             io.BytesIO(image),
             caption=f"📝 Requested by {user_mention}\n🎨 Prompt: {prompt}",
         )
+    except OpenRouterImageError as exc:
+        logger.exception("Edit command failed")
+        await message.reply_text(exc.user_message)
+        raise HandledCommandError("Edit command failed") from exc
     except (
         aiohttp.ClientError,
-        OpenRouterImageError,
         TelegramError,
         TimeoutError,
         TypeError,

--- a/tests/test_command_regressions.py
+++ b/tests/test_command_regressions.py
@@ -474,6 +474,50 @@ class CommandRegressionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(session.request, request)
         self.assertEqual(image, b"image-bytes")
 
+    async def test_edit_explains_content_moderation_rejection(self):
+        message = FakeMessage()
+        context = SimpleNamespace(args=["Remove", "their", "clothes"], bot=object())
+        rejection = ask_module.OpenRouterImageError(
+            400,
+            "Generated image rejected by content moderation.",
+        )
+
+        with (
+            patch.object(ask_module, "get_message", return_value=message),
+            patch.object(
+                ask_module,
+                "ensure_command_available",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(ask_module, "ensure_quota", AsyncMock(return_value=True)),
+            patch.object(
+                ask_module,
+                "model",
+                AsyncMock(return_value=SimpleNamespace(id="image-model")),
+            ),
+            patch.object(
+                ask_module,
+                "generate_image",
+                AsyncMock(side_effect=rejection),
+            ),
+            patch.object(ask_module.logger, "exception"),
+            self.assertRaises(ask_module.HandledCommandError),
+        ):
+            await ask_module.edit(
+                SimpleNamespace(effective_user=message.from_user),
+                context,
+            )
+
+        self.assertEqual(
+            message.replies,
+            [
+                (
+                    "The generated image was rejected by content moderation. "
+                    "Try a different prompt or source image."
+                )
+            ],
+        )
+
     async def test_search_streams_reasoning_then_replaces_it_with_the_answer(self):
         events = []
 


### PR DESCRIPTION
Show users when image generation was rejected by content moderation instead of presenting a generic retry message. Preserve generic handling for transport and unexpected provider failures.