### PR TITLE
fix(ci): install ffmpeg for transcription tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.4.0
+      - name: Install media tools
+        run: sudo apt-get update && sudo apt-get install --yes ffmpeg
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Run tests


### PR DESCRIPTION
## Summary

- Install ffmpeg in the Bun CI test job.
- Match the runtime dependency used by the transcription path.

## Evidence

- Release run 33589191317 reached the transcription test without calling the AI provider and received no RIFF data.
- The same test passes locally when ffmpeg is available.
- The workflow diff passes actionlint.
