### PR TITLE
feat(ui): render static commands with native rich blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SuperSeriousBot has grown with its groups for years. It combines AI, media, sear
 ## Features
 
 - AI: native rich replies, semantic search, image and video generation, custom songs, summaries, and transcription
+- Native Telegram UI: rich tables, lists, details, charts, dates, links, and command dashboards
 - Group memory: semantic `/search`, citations, member personas, and group lore
 - Media: `/set`, `/get`, `/dl`, automatic reel downloads, memes, and quotes
 - Social: `/summon`, `/habit`, `/highlight`, reactions, mentions, and `sed` corrections
@@ -83,6 +84,7 @@ The local Test Server harness uses leased QA credentials from the Telly skill:
 ```bash
 bun run test:e2e
 TELEGRAM_E2E_GROUP=1 bun run test:e2e
+TELEGRAM_E2E_STATIC_RICH=1 TELEGRAM_E2E_GROUP=1 bun run test:e2e
 TELEGRAM_E2E_WEBHOOK=1 bun run test:e2e
 ```
 

--- a/src/app/command.ts
+++ b/src/app/command.ts
@@ -1,6 +1,5 @@
 import {
   Effect,
-  html,
   reply,
   respond,
   respondTo,
@@ -18,6 +17,7 @@ import { Predicate } from "effect";
 import type { ApiConfig } from "./config.ts";
 import { isAdmin } from "./admin.ts";
 import type { AppDependencies } from "./dependencies.ts";
+import { replyBlocks, rich } from "./rich.ts";
 
 export type CommandEffect = Effect.Effect<unknown, unknown, Bot>;
 
@@ -43,11 +43,13 @@ export function usage(
   message: ConversationMessage,
   definition: Pick<CommandDefinition, "description" | "example" | "usage">,
 ) {
-  return answer(message, {
-    linkPreviewOptions: { isDisabled: true },
-    parseMode: "HTML",
-    text: `${html.escape(definition.description)}\n\n<b>Usage:</b>\n<pre>${html.escape(definition.usage)}</pre>\n\n<b>Example:</b>\n<pre>${html.escape(definition.example)}</pre>`,
-  });
+  return replyBlocks(message, [
+    rich.paragraph(definition.description),
+    rich.heading("Usage", 4),
+    rich.pre(definition.usage),
+    rich.heading("Example", 4),
+    rich.pre(definition.example),
+  ]);
 }
 
 function enabled(definition: CommandDefinition, dependencies: AppDependencies): boolean {

--- a/src/app/rich.ts
+++ b/src/app/rich.ts
@@ -8,10 +8,13 @@ import {
   sendMessage,
   sendRichMessage,
   type BotApiError,
+  type ConversationMessage,
   type ConversationTarget,
+  type InputRichBlock,
   type InlineKeyboardMarkup,
   type Message,
   type ReplyTarget,
+  type RichText,
 } from "telly";
 
 const plainMessageLimit = 4_096;
@@ -27,6 +30,53 @@ interface RichOptions {
 }
 
 type RichTarget = ConversationTarget | ReplyTarget;
+
+export const rich = {
+  bold: (text: RichText): RichText => ({ text, type: "bold" }),
+  code: (text: RichText): RichText => ({ text, type: "code" }),
+  command: (command: string): RichText => ({
+    botCommand: command,
+    text: command,
+    type: "bot_command",
+  }),
+  dateTime: (unixTime: number, dateTimeFormat: string, text: RichText): RichText => ({
+    dateTimeFormat,
+    text,
+    type: "date_time",
+    unixTime,
+  }),
+  footer: (text: RichText): InputRichBlock => ({ text, type: "footer" }),
+  heading: (text: RichText, size = 2): InputRichBlock => ({ size, text, type: "heading" }),
+  link: (text: RichText, url: string): RichText => ({ text, type: "url", url }),
+  list: (
+    items: ReadonlyArray<RichText>,
+    options: { readonly ordered?: boolean } = {},
+  ): InputRichBlock => ({
+    items: items.map((text, index) => ({
+      blocks: [{ text, type: "paragraph" }],
+      ...(options.ordered === true ? { type: "1", value: index + 1 } : {}),
+    })),
+    type: "list",
+  }),
+  paragraph: (text: RichText): InputRichBlock => ({ text, type: "paragraph" }),
+  pre: (text: RichText): InputRichBlock => ({ text, type: "pre" }),
+  table: (
+    rows: ReadonlyArray<ReadonlyArray<RichText>>,
+    options: { readonly header?: boolean } = {},
+  ): InputRichBlock => ({
+    cells: rows.map((row, rowIndex) => row.map((text) => ({
+      align: "left",
+      text,
+      valign: "middle",
+      ...(options.header === true && rowIndex === 0 ? { isHeader: true as const } : {}),
+    }))),
+    type: "table",
+  }),
+} as const;
+
+function conversationTarget(message: ConversationMessage): RichTarget {
+  return message.chat.type === "private" ? respondTo(message) : replyTo(message);
+}
 
 function plain(target: RichTarget, text: string, options: RichOptions) {
   const replyMarkup = {
@@ -64,12 +114,23 @@ function sendAt(target: RichTarget, text: string, options: RichOptions) {
 }
 
 export const replyRich = Effect.fn("replyRich")(function* (
-  message: Message,
+  message: ConversationMessage,
   text: string,
   options: RichOptions = {},
 ) {
-  const target = message.chat.type === "private" ? respondTo(message) : replyTo(message);
-  return yield* sendAt(target, text, options);
+  return yield* sendAt(conversationTarget(message), text, options);
+});
+
+export const replyBlocks = Effect.fn("replyBlocks")(function* (
+  message: ConversationMessage,
+  blocks: ReadonlyArray<InputRichBlock>,
+  options: Pick<RichOptions, "replyMarkup"> = {},
+) {
+  return yield* sendRichMessage({
+    ...conversationTarget(message),
+    ...(options.replyMarkup === undefined ? {} : { replyMarkup: options.replyMarkup }),
+    richMessage: { blocks },
+  });
 });
 
 export const sendRich = Effect.fn("sendRich")(function* (

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -8,12 +8,12 @@ import {
 } from "telly";
 
 import {
-  answer,
   botCommands,
   commandHandlers,
   type CommandDefinition,
 } from "./app/command.ts";
 import type { AppDependencies } from "./app/dependencies.ts";
+import { replyBlocks, rich } from "./app/rich.ts";
 import { basicCommands } from "./features/basic.ts";
 import { informationCommands } from "./features/information.ts";
 import { moderationCommands } from "./features/moderation.ts";
@@ -70,9 +70,14 @@ export function createSuperSeriousBot(dependencies: AppDependencies) {
     description: "Show every enabled command.",
     example: "/help",
     names: ["help"],
-    run: ({ message }) => answer(message, botCommands(featureCommands, dependencies).map((command) =>
-      `/${command.command} — ${command.description}`
-    ).join("\n")),
+    run: ({ message }) => replyBlocks(message, [
+      rich.heading("📺 SuperSeriousBot commands"),
+      rich.list(botCommands(featureCommands, dependencies).map((command) => [
+        rich.command(`/${command.command}`),
+        ` — ${command.description}`,
+      ])),
+      rich.footer("Only commands enabled by this bot's current integrations are shown."),
+    ]),
     usage: "/help",
   };
   const definitions = [help, ...featureCommands];

--- a/src/features/cron.ts
+++ b/src/features/cron.ts
@@ -6,7 +6,6 @@ import {
   editMessageReplyMarkup,
   editMessageText,
   Effect,
-  html,
   Schema,
 } from "telly";
 
@@ -20,7 +19,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
-import { richMarkdownPrompt, sendRich } from "../app/rich.ts";
+import { replyBlocks, rich, richMarkdownPrompt, sendRich } from "../app/rich.ts";
 
 const defaultTimezone = "Asia/Kolkata";
 const CronDraft = Schema.Struct({
@@ -74,6 +73,27 @@ function deleteKeyboard(taskId: number) {
       ...CronCallback.button("🗑️ Delete", { taskId }),
       style: "danger" as const,
     }]],
+  };
+}
+
+function cronTaskDetails(task: {
+  readonly cronExpr: string;
+  readonly id: number;
+  readonly next: number;
+  readonly timezone: string;
+  readonly title: string;
+}) {
+  return {
+    blocks: [{
+      ...rich.table([
+        ["Schedule", rich.code(task.cronExpr)],
+        ["Timezone", rich.code(task.timezone)],
+        ["Next run", rich.dateTime(task.next, "wDT", "scheduled")],
+      ]),
+      isCompact: true as const,
+    }],
+    summary: [rich.code(`#${task.id}`), " ", rich.bold(task.title)],
+    type: "details" as const,
   };
 }
 
@@ -140,13 +160,17 @@ export function cronFeature(dependencies: AppDependencies) {
           [match.message.chat.id, user.id],
         );
         if (rows.length === 0) return yield* usage(match.message, definition);
-        const entries = rows.map((row) =>
-          `<code>${rowNumber(row, "id")}</code>. <b>${html.escape(rowString(row, "title"))}</b>\n<code>${html.escape(rowString(row, "cron_expr"))}</code> <code>${html.escape(rowString(row, "timezone"))}</code>\nNext: <tg-time unix="${rowNumber(row, "next_run_time")}" format="wDT">scheduled</tg-time>`
-        );
-        return yield* answer(match.message, {
-          parseMode: "HTML",
-          text: `<b>Your cron tasks in this chat:</b>\n\n${entries.join("\n\n")}`,
-        });
+        return yield* replyBlocks(match.message, [
+          rich.heading("🕰️ Your scheduled AI tasks"),
+          ...rows.map((row) => cronTaskDetails({
+            cronExpr: rowString(row, "cron_expr"),
+            id: rowNumber(row, "id"),
+            next: rowNumber(row, "next_run_time"),
+            timezone: rowString(row, "timezone"),
+            title: rowString(row, "title"),
+          })),
+          rich.footer(["Manage a task with ", rich.code("/cron run <id>"), " or ", rich.code("/cron del <id>")]),
+        ]);
       }
       const action = match.args[0]?.toLowerCase();
       if (action === "del" || action === "run") {
@@ -211,8 +235,10 @@ export function cronFeature(dependencies: AppDependencies) {
       yield* editMessageText({
         chatId: status.chat.id,
         messageId: status.messageId,
-        parseMode: "HTML",
-        text: `Created cron task <code>${id}</code>.\n\n<b>${html.escape(draft.title)}</b>\n<code>${html.escape(draft.cronExpr)}</code> <code>${html.escape(draft.timezone)}</code>\nNext: <tg-time unix="${draft.next}" format="wDT">scheduled</tg-time>`,
+        richMessage: { blocks: [
+          rich.heading("✅ Scheduled AI task created", 3),
+          cronTaskDetails({ id, ...draft }),
+        ] },
       });
     }),
     usage: "/cron [schedule + task]\n/cron del [id]\n/cron run [id]",

--- a/src/features/football.ts
+++ b/src/features/football.ts
@@ -3,15 +3,17 @@ import {
   answerCallback,
   callbackData,
   Effect,
-  html,
   Schema,
-  sendMessage,
+  sendRichMessage,
+  type InputRichBlock,
+  type RichText,
 } from "telly";
 
 import { callbackRoute } from "../app/callback.ts";
 import { answer, type CommandDefinition } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 
 const competitions = [
   { name: "Premier League", slug: "eng.1" },
@@ -334,26 +336,45 @@ function streamLinks(dependencies: AppDependencies) {
 }
 
 function renderFixtures(fixtures: ReadonlyArray<Fixture>, odds: ReadonlyMap<string, Odds>, streams: ReadonlyArray<{ readonly away: string; readonly home: string; readonly url: string }>, heading: string) {
-  const lines = [heading];
+  const blocks: Array<InputRichBlock> = [rich.heading(heading)];
   let competition = "";
   for (const fixture of fixtures) {
     if (fixture.competitionName !== competition) {
       competition = fixture.competitionName;
-      lines.push("", `<b>${html.escape(competition)}</b>`);
+      blocks.push(rich.heading(competition, 4));
     }
     const stream = streams.find((item) =>
       hasTeam(item.home, fixture.homeTeam) && hasTeam(item.away, fixture.awayTeam) ||
       hasTeam(item.home, fixture.awayTeam) && hasTeam(item.away, fixture.homeTeam));
-    lines.push(`• ${html.escape(fixture.homeTeam)} vs ${html.escape(fixture.awayTeam)}${stream === undefined ? "" : ` · <a href="${stream.url}">📺 watch</a>`}`);
+    const matchup: RichText = [
+      `${fixture.homeTeam} vs ${fixture.awayTeam}`,
+      ...(stream === undefined ? [] : [" · ", rich.link("📺 watch", stream.url)]),
+    ];
+    blocks.push(rich.list([matchup]));
   }
-  lines.push("", `<tg-time unix="${fixtures[0]?.kickoffTime ?? 0}" format="r">Kickoff</tg-time>`, "", "📊 <b>Polymarket odds</b>");
-  for (const fixture of fixtures) {
-    const value = odds.get(fixture.providerId);
-    lines.push(value === undefined
-      ? `• ${html.escape(fixture.homeTeam)} vs ${html.escape(fixture.awayTeam)}: not available yet`
-      : `• ${html.escape(fixture.homeTeam)} <b>${(value.home * 100).toFixed(0)}%</b> · Draw <b>${(value.draw * 100).toFixed(0)}%</b> · ${html.escape(fixture.awayTeam)} <b>${(value.away * 100).toFixed(0)}%</b> · <a href="https://polymarket.com/event/${value.slug}">market</a>`);
-  }
-  return lines.join("\n");
+  blocks.push(rich.paragraph(rich.dateTime(
+    fixtures[0]?.kickoffTime ?? 0,
+    "r",
+    "Kickoff",
+  )));
+  const table = rich.table([
+    ["Match", "Home", "Draw", "Away", "Market"],
+    ...fixtures.map((fixture) => {
+      const value = odds.get(fixture.providerId);
+      return value === undefined
+        ? [`${fixture.homeTeam} vs ${fixture.awayTeam}`, "—", "—", "—", "Pending"]
+        : [
+            `${fixture.homeTeam} vs ${fixture.awayTeam}`,
+            `${(value.home * 100).toFixed(0)}%`,
+            `${(value.draw * 100).toFixed(0)}%`,
+            `${(value.away * 100).toFixed(0)}%`,
+            rich.link("Polymarket", `https://polymarket.com/event/${encodeURIComponent(value.slug)}`),
+          ];
+    }),
+  ], { header: true });
+  blocks.push(rich.heading("📊 Polymarket odds", 4));
+  blocks.push({ ...table, isCompact: true, isStriped: true });
+  return blocks;
 }
 
 export function footballFeature(dependencies: AppDependencies) {
@@ -377,11 +398,10 @@ export function footballFeature(dependencies: AppDependencies) {
         streamLinks(dependencies),
       ], { concurrency: "unbounded" });
       const odds = new Map(oddsValues.filter((entry): entry is readonly [string, Odds] => entry[1] !== undefined));
-      yield* answer(match.message, {
-        linkPreviewOptions: { isDisabled: true },
-        parseMode: "HTML",
-        text: renderFixtures(fixtures, odds, streams, "⚽ <b>Next Big Six match</b>"),
-      });
+      yield* replyBlocks(
+        match.message,
+        renderFixtures(fixtures, odds, streams, "⚽ Next Big Six match"),
+      );
     }),
     usage: "/next",
   };
@@ -479,13 +499,22 @@ export function footballFeature(dependencies: AppDependencies) {
         !delivered.has(`${fixture.providerId}:${rowNumber(member, "user_id")}`)));
       for (let index = 0; index < members.length; index += 5) {
         const chunk = members.slice(index, index + 5);
-        const mentions = chunk.map((member) => `<a href="tg://user?id=${rowNumber(member, "user_id")}">${html.escape(rowString(member, "display_name"))}</a>`).join(" ");
-        const result = yield* Effect.result(sendMessage({
+        const mentions: RichText = chunk.flatMap((member, index) => [
+          ...(index === 0 ? [] : [" "]),
+          rich.link(
+            rowString(member, "display_name"),
+            `tg://user?id=${rowNumber(member, "user_id")}`,
+          ),
+        ]);
+        const result = yield* Effect.result(sendRichMessage({
           chatId,
-          linkPreviewOptions: { isDisabled: true },
-          parseMode: "HTML",
           replyMarkup: keyboard(),
-          text: `${renderFixtures(fixtures, odds, streams, "⚽ <b>Kickoff in five minutes</b>")}\n\n${mentions}`,
+          richMessage: {
+            blocks: [
+              ...renderFixtures(fixtures, odds, streams, "⚽ Kickoff in five minutes"),
+              rich.paragraph(mentions),
+            ],
+          },
         }));
         if (result._tag === "Failure") continue;
         yield* Effect.forEach(chunk, (member) => Effect.forEach(fixtures, (fixture) =>

--- a/src/features/information.ts
+++ b/src/features/information.ts
@@ -1,6 +1,5 @@
 import {
   Effect,
-  html,
   Schema,
 } from "telly";
 
@@ -11,6 +10,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 import { truncate } from "../app/text.ts";
 
 const DictionaryResponse = Schema.Array(Schema.Struct({
@@ -86,17 +86,21 @@ function definitionCommand(dependencies: AppDependencies): CommandDefinition {
       const phonetic = entry.phonetics?.find((item) => item.text !== undefined)?.text;
       const meaning = entry.meanings?.[0];
       const firstDefinition = meaning?.definitions?.[0];
-      let text = `<b>${html.escape(entry.word)}</b>`;
-      if (phonetic !== undefined) text += `\n🗣️ ${html.escape(phonetic)}`;
+      const blocks = [rich.heading(`📖 ${entry.word}`)];
+      if (phonetic !== undefined) blocks.push(rich.paragraph(["🗣️ ", rich.code(phonetic)]));
       if (meaning?.partOfSpeech !== undefined && firstDefinition !== undefined) {
-        text += `\n\n<b>${html.escape(meaning.partOfSpeech)}</b>`;
-        text += `\n  -  ${html.escape(firstDefinition.definition)}`;
+        blocks.push(rich.heading(meaning.partOfSpeech, 4));
+        blocks.push(rich.paragraph(firstDefinition.definition));
         const synonyms = firstDefinition.synonyms?.slice(0, 2) ?? [];
         if (synonyms.length > 0) {
-          text += `\n\nSynonyms:${synonyms.map((synonym) => `\n  - ${html.escape(synonym)}`).join("")}`;
+          blocks.push({
+            blocks: [rich.list(synonyms)],
+            summary: "Synonyms",
+            type: "details",
+          });
         }
       }
-      return yield* answer(match.message, { parseMode: "HTML", text });
+      return yield* replyBlocks(match.message, blocks);
     }),
     usage: "/define [word]",
   };
@@ -131,12 +135,21 @@ function urbanDictionaryCommand(dependencies: AppDependencies): CommandDefinitio
       const permalink = URL.canParse(entry.permalink) && ["http:", "https:"].includes(
         new URL(entry.permalink).protocol,
       ) ? entry.permalink : "";
-      const prefix = wordOfTheDay ? `📅 Word of the Day (${entry.date ?? "Today"}):\n\n` : "";
-      return yield* answer(match.message, {
-        linkPreviewOptions: { isDisabled: true },
-        parseMode: "HTML",
-        text: `${html.escape(prefix)}<a href="${html.escape(permalink)}"><b>${html.escape(entry.word)}</b></a>\n\n${html.escape(truncate(entry.definition, 1_000))}\n\n<i>${html.escape(truncate(entry.example, 1_000))}</i>\n\n<pre>👍 x ${entry.thumbs_up}</pre>`,
-      });
+      const title = permalink.length === 0
+        ? entry.word
+        : rich.link(entry.word, permalink);
+      return yield* replyBlocks(match.message, [
+        rich.heading(wordOfTheDay ? ["📅 Word of the day — ", title] : ["📚 ", title]),
+        rich.paragraph(truncate(entry.definition, 1_000)),
+        {
+          blocks: [rich.paragraph(truncate(entry.example, 1_000))],
+          type: "blockquote",
+        },
+        rich.footer([
+          `👍 ${entry.thumbs_up}`,
+          ...(wordOfTheDay ? [` · ${entry.date ?? "Today"}`] : []),
+        ]),
+      ]);
     }),
     usage: "/ud [word] or /ud",
   };
@@ -301,10 +314,21 @@ function weatherCommand(dependencies: AppDependencies): CommandDefinition {
       const renderedAqi = aqiValue === undefined || aqiValue === "-"
         ? "Unavailable"
         : String(Math.trunc(Number(aqiValue)));
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `<b>${html.escape(address)}</b>\n\n${html.escape(current.condition.text)}\n\n🌡️ <b>Temperature:</b> ${current.temp_c.toFixed(1)} °C\n🫠 <b>Feels like:</b> ${current.feelslike_c.toFixed(1)} °C\n💦 <b>Humidity:</b> ${current.humidity}%\n💨 <b>Wind:</b> ${current.wind_kph.toFixed(1)} km/h ${html.escape(current.wind_dir)}\n🛰 <b>AQI:</b> ${renderedAqi}\n🌫 <b>PM2.5:</b> ${pollutant(current.air_quality?.pm2_5)}\n🏭 <b>PM10:</b> ${pollutant(current.air_quality?.pm10)}`,
-      });
+      const table = rich.table([
+        ["Measure", "Value"],
+        ["🌡️ Temperature", `${current.temp_c.toFixed(1)} °C`],
+        ["🫠 Feels like", `${current.feelslike_c.toFixed(1)} °C`],
+        ["💦 Humidity", `${current.humidity}%`],
+        ["💨 Wind", `${current.wind_kph.toFixed(1)} km/h ${current.wind_dir}`],
+        ["🛰 AQI", renderedAqi],
+        ["🌫 PM2.5", pollutant(current.air_quality?.pm2_5)],
+        ["🏭 PM10", pollutant(current.air_quality?.pm10)],
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        rich.heading(`🌦️ ${address}`),
+        rich.paragraph(current.condition.text),
+        { ...table, isCompact: true, isStriped: true },
+      ]);
     }),
     usage: "/w [location]",
   };

--- a/src/features/moderation.ts
+++ b/src/features/moderation.ts
@@ -8,6 +8,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 
 function adminOnly(dependencies: AppDependencies, userId: number | undefined) {
   return userId !== undefined && isAdmin(dependencies, userId);
@@ -77,13 +78,19 @@ function blocklistCommand(dependencies: AppDependencies): CommandDefinition {
          FROM command_blocklist ORDER BY blocked_at DESC`,
       );
       if (rows.length === 0) return yield* answer(match.message, "No blocked users found.");
-      const items = rows.map((row) =>
-        `User: <code>${rowNumber(row, "user_id")}</code>\nCommand: /${html.escape(rowString(row, "command"))}\nBlocked by: <code>${rowNumber(row, "blocked_by")}</code>\nWhen: ${html.escape(rowString(row, "blocked_at"))}`
-      ).join("\n\n");
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `🚫 <b>Command Blocklist:</b>\n\n${items}`,
-      });
+      const table = rich.table([
+        ["User", "Command", "Blocked by", "When"],
+        ...rows.map((row) => [
+          rich.code(String(rowNumber(row, "user_id"))),
+          rich.command(`/${rowString(row, "command")}`),
+          rich.code(String(rowNumber(row, "blocked_by"))),
+          rich.code(rowString(row, "blocked_at")),
+        ]),
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        rich.heading("🚫 Command blocklist"),
+        { ...table, isCompact: true, isStriped: true },
+      ]);
     }),
     usage: "/blocklist",
   };

--- a/src/features/reminders.ts
+++ b/src/features/reminders.ts
@@ -12,14 +12,10 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 
 const claimLeaseSeconds = 5 * 60;
 const maximumAttempts = 5;
-
-function telegramTime(unix: number, fallback: string, format?: string): string {
-  const formatAttribute = format === undefined ? "" : ` format="${format}"`;
-  return `<tg-time unix="${unix}"${formatAttribute}>${html.escape(fallback)}</tg-time>`;
-}
 
 export function parseReminderTime(text: string, now: Date): Date | undefined {
   const hasIst = /\bIST\b/iu.test(text);
@@ -46,15 +42,20 @@ export function reminderFeature(dependencies: AppDependencies) {
           [user.id, match.message.chat.id],
         );
         if (rows.length === 0) return yield* usage(match.message, definition);
-        const items = rows.map((row, index) => {
+        const items = rows.map((row) => {
           const target = rowNumber(row, "target_time");
           const fallback = new Date(target * 1_000).toISOString().replace("T", " ").slice(0, 16);
-          return `${index + 1}. <code>${html.escape(rowString(row, "title"))}</code> ${telegramTime(target, `${fallback} UTC`, "r")}`;
+          return [
+            rich.code(rowString(row, "title")),
+            " — ",
+            rich.dateTime(target, "r", `${fallback} UTC`),
+          ];
         });
-        return yield* answer(match.message, {
-          parseMode: "HTML",
-          text: `⏰ Your reminders in this chat:\n\n${items.join("\n")}`,
-        });
+        return yield* replyBlocks(match.message, [
+          rich.heading("⏰ Your reminders"),
+          rich.list(items, { ordered: true }),
+          rich.footer("Times update automatically in Telegram."),
+        ]);
       }
       const separator = match.argText.indexOf(" - ");
       if (separator === -1) return yield* usage(match.message, definition);
@@ -79,10 +80,14 @@ export function reminderFeature(dependencies: AppDependencies) {
         "INSERT INTO reminders (chat_id, user_id, title, target_time) VALUES (?, ?, ?, ?)",
         [match.message.chat.id, user.id, title, unix],
       );
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `I will remind you about <code>${html.escape(title)}</code> on ${telegramTime(unix, target.toISOString(), "wDT")}`,
-      });
+      return yield* replyBlocks(match.message, [
+        rich.heading("⏰ Reminder scheduled", 3),
+        rich.paragraph(["I will remind you about ", rich.code(title), " on ", rich.dateTime(
+          unix,
+          "wDT",
+          target.toISOString(),
+        )]),
+      ]);
     }),
     usage: "/remind [reminder name] - [target time]",
   };

--- a/src/features/settings.ts
+++ b/src/features/settings.ts
@@ -17,6 +17,7 @@ import {
 } from "../app/command.ts";
 import { rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 
 export const defaultModels = {
   ask: "openrouter/x-ai/grok-4.3",
@@ -99,13 +100,18 @@ function modelCommand(dependencies: AppDependencies): CommandDefinition {
         const models = yield* Effect.all(Object.fromEntries(
           modelCommands.map((name) => [name, getModel(dependencies, name)]),
         ));
-        const lines = modelCommands.map((name) =>
-          `• <b>/${name}</b>: <code>${html.escape(models[name] ?? defaultModels[name])}</code>`
-        );
-        return yield* answer(match.message, {
-          parseMode: "HTML",
-          text: `📋 <b>Current AI Models:</b>\n\n${lines.join("\n")}\n\n<b>Usage:</b> <code>/model &lt;command&gt; &lt;model_name&gt;</code>`,
-        });
+        const table = rich.table([
+          ["Command", "Model"],
+          ...modelCommands.map((name) => [
+            rich.command(`/${name}`),
+            rich.code(models[name] ?? defaultModels[name]),
+          ]),
+        ], { header: true });
+        return yield* replyBlocks(match.message, [
+          rich.heading("📋 Current AI models"),
+          { ...table, isBordered: true, isCompact: true },
+          rich.footer(["Usage: ", rich.code("/model <command> <model_name>")]),
+        ]);
       }
       const requested = match.args[0]?.toLowerCase();
       const targets = requested === "all"
@@ -150,10 +156,12 @@ function thinkingCommand(dependencies: AppDependencies): CommandDefinition {
       const level = match.args[0]?.toLowerCase();
       if (level === undefined) {
         const current = yield* getThinking(dependencies);
-        return yield* answer(match.message, {
-          parseMode: "HTML",
-          text: `🧠 <b>AI Thinking Level</b>\n\nCurrent level: <code>${html.escape(current)}</code>\n\nAvailable: none, minimal, low, medium, high`,
-        });
+        return yield* replyBlocks(match.message, [
+          rich.heading("🧠 AI thinking level"),
+          rich.paragraph(["Current level: ", rich.code(current)]),
+          rich.list(thinkingLevels.map((candidate) => rich.code(candidate))),
+          rich.footer(["Usage: ", rich.code("/thinking <level>")]),
+        ]);
       }
       if (!thinkingLevels.some((candidate) => candidate === level)) {
         return yield* answer(match.message, `❌ Invalid thinking level: ${level}`);
@@ -223,6 +231,14 @@ function keyboard(chatId: number, states: Readonly<Record<ToggleKey, boolean>>) 
   };
 }
 
+function settingsBlocks(chatId: number) {
+  return [
+    rich.heading("⚙️ Group settings"),
+    rich.paragraph(["Chat: ", rich.code(String(chatId))]),
+    rich.footer("Use the buttons below to enable or disable each feature."),
+  ];
+}
+
 function settingsCommand(dependencies: AppDependencies): CommandDefinition {
   return {
     description: "Manage this group's bot settings.",
@@ -237,10 +253,8 @@ function settingsCommand(dependencies: AppDependencies): CommandDefinition {
         return yield* answer(match.message, "Only group admins can change settings.");
       }
       const states = yield* settingStates(dependencies, match.message.chat.id);
-      return yield* answer(match.message, {
-        parseMode: "HTML",
+      return yield* replyBlocks(match.message, settingsBlocks(match.message.chat.id), {
         replyMarkup: keyboard(match.message.chat.id, states),
-        text: `<b>Group settings</b>\n<code>${match.message.chat.id}</code>`,
       });
     }),
     usage: "/settings",
@@ -295,9 +309,8 @@ export function settingsCallback(dependencies: AppDependencies) {
     if ("ephemeralMessageId" in target) return;
     yield* ignoreUnchangedMessage(editMessageText({
       ...target,
-      parseMode: "HTML",
+      richMessage: { blocks: settingsBlocks(data.chatId) },
       replyMarkup: keyboard(data.chatId, next),
-      text: `<b>Group settings</b>\n<code>${data.chatId}</code>`,
     }));
   }));
 }

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -7,6 +7,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { replyBlocks, rich } from "../app/rich.ts";
 
 function readableTime(now: Date, input: string): string {
   const seconds = Math.abs(now.getTime() - new Date(input).getTime()) / 1_000;
@@ -50,14 +51,18 @@ function statsCommand(dependencies: AppDependencies, todayOnly: boolean): Comman
       const total = rows.reduce((sum, row) => sum + rowNumber(row, "user_count"), 0);
       if (total === 0) return yield* answer(match.message, "No messages recorded.");
       const title = match.message.chat.title ?? String(match.message.chat.id);
-      const lines = rows.map((row) => {
-        const count = rowNumber(row, "user_count");
-        return `<code>${(count / total * 100).toFixed(1).padStart(4)}% - ${html.escape(rowString(row, "name"))}</code>`;
-      });
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `Stats for <b>${html.escape(title)}:</b>\n\n${lines.join("\n")}\n\nTotal messages: <b>${total}</b>`,
-      });
+      const table = rich.table([
+        ["Member", "Messages", "Share"],
+        ...rows.map((row) => {
+          const count = rowNumber(row, "user_count");
+          return [rowString(row, "name"), rich.code(String(count)), `${(count / total * 100).toFixed(1)}%`];
+        }),
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        rich.heading(`${todayOnly ? "📊 Today's activity" : "📈 Group activity"} — ${title}`),
+        { ...table, isCompact: true, isStriped: true },
+        rich.footer(["Total messages: ", rich.bold(String(total))]),
+      ]);
     }),
     usage: todayOnly ? "/stats" : "/gstats",
   };
@@ -139,13 +144,18 @@ function botStatsCommand(dependencies: AppDependencies): CommandDefinition {
          FROM command_stats GROUP BY command ORDER BY command_count DESC LIMIT 10`,
       );
       const totalRow = yield* dependencies.database.one("SELECT COUNT(*) AS total FROM command_stats");
-      const lines = rows.map((row) =>
-        `<code>${String(rowNumber(row, "command_count")).padStart(4)} - /${html.escape(rowString(row, "command"))}</code>`
-      );
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `Stats for <b>@${html.escape(bot.username ?? bot.firstName)}:</b>\n\n${lines.join("\n")}\n\nTotal: <b>${totalRow === undefined ? 0 : rowNumber(totalRow, "total")}</b>`,
-      });
+      const table = rich.table([
+        ["Command", "Runs"],
+        ...rows.map((row) => [
+          rich.command(`/${rowString(row, "command")}`),
+          rich.code(String(rowNumber(row, "command_count"))),
+        ]),
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        rich.heading(`🤖 @${bot.username ?? bot.firstName} command stats`),
+        { ...table, isBordered: true, isCompact: true },
+        rich.footer(["Total runs: ", rich.bold(String(totalRow === undefined ? 0 : rowNumber(totalRow, "total")))]),
+      ]);
     }),
     usage: "/botstats",
   };
@@ -199,13 +209,16 @@ function friendsCommand(dependencies: AppDependencies): CommandDefinition {
       }
       const outgoing = rows.filter((row) => row["direction"] === "out").slice(0, 3);
       const incoming = rows.filter((row) => row["direction"] === "in").slice(0, 3);
-      const render = (heading: string, arrow: string, values: typeof rows) => values.length === 0
-        ? ""
-        : `\n\n${heading}${values.map((row) => `\n<code>${String(rowNumber(row, "weight")).padStart(6)} ${arrow} ${html.escape(rowString(row, "name"))}</code>`).join("")}`;
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `From the social graph of <b>${html.escape(match.message.chat.title ?? String(match.message.chat.id))}</b>:${render("You have the strongest connections to:", "⟶", outgoing)}${render("You have the strongest connections from:", "←", incoming)}`,
-      });
+      const table = rich.table([
+        ["Direction", "Member", "Interactions"],
+        ...outgoing.map((row) => ["You →", rowString(row, "name"), rich.code(String(rowNumber(row, "weight")))]),
+        ...incoming.map((row) => ["You ←", rowString(row, "name"), rich.code(String(rowNumber(row, "weight")))]),
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        rich.heading(`🕸️ Your social graph — ${match.message.chat.title ?? String(match.message.chat.id)}`),
+        { ...table, isCompact: true, isStriped: true },
+        rich.footer("Arrows show who mentions or replies to whom."),
+      ]);
     }),
     usage: "/friends",
   };
@@ -312,14 +325,26 @@ function userStatsCommand(dependencies: AppDependencies): CommandDefinition {
         return `${labels[index]} | ${"█".repeat(width).padEnd(20)} ${count}`;
       }).join("\n");
       const name = target.username ?? target.firstName;
-      if (week === 0) return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `User stats for <b>${html.escape(name)}</b> in <b>${html.escape(match.message.chat.title ?? String(match.message.chat.id))}</b>\n\nNo messages in the last 7 days.`,
-      });
-      return yield* answer(match.message, {
-        parseMode: "HTML",
-        text: `User stats for <b>${html.escape(name)}</b> in <b>${html.escape(match.message.chat.title ?? String(match.message.chat.id))}</b>\n\nLast 7d: <b>${week}</b> msgs (${group === 0 ? "0.0" : (week / group * 100).toFixed(1)}% of group) • avg ${(week / 7).toFixed(2)}/day\nLifetime in this chat: <b>${lifetime}</b> msgs\nMost active hour: <b>${hour === undefined ? "-" : `${String(hour).padStart(2, "0")}:00`}</b>\nMost active day: <b>${day === undefined ? "-" : dayNames[Number(day)]}</b>\n\n<pre>${bars}</pre>\nSparkline: <code>${sparkline(counts)}</code>`,
-      });
+      const heading = rich.heading(`📊 ${name} — ${match.message.chat.title ?? String(match.message.chat.id)}`);
+      if (week === 0) return yield* replyBlocks(match.message, [
+        heading,
+        rich.paragraph("No messages in the last 7 days."),
+      ]);
+      const table = rich.table([
+        ["Metric", "Value"],
+        ["Last 7 days", `${week} messages`],
+        ["Group share", `${group === 0 ? "0.0" : (week / group * 100).toFixed(1)}%`],
+        ["Daily average", (week / 7).toFixed(2)],
+        ["Lifetime", `${lifetime} messages`],
+        ["Most active hour", hour === undefined ? "—" : `${String(hour).padStart(2, "0")}:00`],
+        ["Most active day", day === undefined ? "—" : dayNames[Number(day)] ?? "—"],
+      ], { header: true });
+      return yield* replyBlocks(match.message, [
+        heading,
+        { ...table, isCompact: true, isStriped: true },
+        rich.pre(bars),
+        rich.footer(["7-day sparkline: ", rich.code(sparkline(counts))]),
+      ]);
     }),
     usage: "/ustats [username]",
   };

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -120,6 +120,7 @@ try {
 
   const webhookMode = process.env.TELEGRAM_E2E_WEBHOOK === "1";
   const aiMode = process.env.TELEGRAM_E2E_AI === "1";
+  const staticRichMode = process.env.TELEGRAM_E2E_STATIC_RICH === "1";
   let openrouterBaseUrl = "";
   if (aiMode) {
     mockAi = Bun.serve({
@@ -224,6 +225,15 @@ try {
           { atMs: 1_500, text: "/ask answer with the test marker", type: "send" },
         ],
       }
+    : staticRichMode
+    ? {
+        actions: [
+          { atMs: 0, text: "/help", type: "send" },
+          { atMs: 1_000, text: "/model", type: "send" },
+          { atMs: 2_000, text: "/thinking", type: "send" },
+          ...(groupMode ? [{ atMs: 3_000, text: "/settings", type: "send" }] : []),
+        ],
+      }
     : groupMode
     ? {
         actions: [
@@ -248,7 +258,7 @@ try {
     "--scenario",
     scenarioPath,
     "--seconds",
-    groupMode ? "15" : "8",
+    groupMode || staticRichMode ? "15" : "8",
     "--record",
     eventsPath,
     "--output",
@@ -270,6 +280,14 @@ try {
       aiRequests.length === 1 &&
       aiRequests[0]?.body?.reasoning?.effort === "high" &&
       aiRequests[0]?.userAgent?.includes("ai-sdk/openrouter/3.0.0") === true
+    : staticRichMode
+    ? revisions.some((text) => text.includes("SuperSeriousBot commands")) &&
+      revisions.some((text) => text.includes("Current AI models")) &&
+      revisions.some((text) => text.includes("AI thinking level")) &&
+      (!groupMode || revisions.some((text) => text.includes("Group settings"))) &&
+      events.filter((event) =>
+        event.isSut === true && event.contentType === "messageRichMessage"
+      ).length >= (groupMode ? 4 : 3)
     : groupMode
     ? revisions.some((text) => text.includes("[alpha] (1 members)")) &&
       revisions.some((text) => text.includes("Created a new habit #walk")) &&

--- a/tests/football.test.ts
+++ b/tests/football.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { Effect, type Update } from "telly";
 
 import type { Fetch } from "../src/app/http.ts";
-import { commandUpdate, fixture } from "./harness.ts";
+import { commandUpdate, fixture, richContent } from "./harness.ts";
 
 const kickoff = Math.floor(new Date("2026-09-01T12:05:00Z").getTime() / 1_000);
 
@@ -52,13 +52,6 @@ function streamPage() {
   return `<a href="https://thestreameast.one/watch/premier-league/arsenal-coventry/1">
     <span class="d-md-inline ">Arsenal vs Coventry City</span>
   </a>`;
-}
-
-function requestText(params: unknown): string {
-  if (typeof params !== "object" || params === null) throw new Error("Telegram request missing");
-  const text = Reflect.get(params, "text");
-  if (typeof text !== "string") throw new Error("Telegram request has no text");
-  return text;
 }
 
 async function storeFixture(
@@ -129,14 +122,12 @@ test("next command renders odds and a matching watch link", async () => {
     database.close();
   }
 
-  const message = fake.requests.find((request) => request.method === "sendMessage");
-  const text = requestText(message?.params);
-  expect(message?.params).toMatchObject({
-    link_preview_options: { is_disabled: true },
-    parse_mode: "HTML",
-  });
-  expect(text).toContain("Arsenal <b>62%</b> · Draw <b>23%</b> · Coventry City <b>15%</b>");
-  expect(text).toContain("📺 watch</a>");
+  const message = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(message?.params);
+  expect(content.text).toContain("Arsenal vs Coventry City");
+  expect(content.text).toContain("62%\n23%\n15%");
+  expect(content.text).toContain("📺 watch");
+  expect(content.types).toContain("table");
 });
 
 test("football buttons join and leave the current group", async () => {
@@ -220,11 +211,12 @@ test("football worker delivers rich alerts once per member", async () => {
   ));
   database.close();
 
-  const alerts = fake.requests.filter((request) => request.method === "sendMessage");
-  const text = requestText(alerts[0]?.params);
+  const alerts = fake.requests.filter((request) => request.method === "sendRichMessage");
+  const content = richContent(alerts[0]?.params);
   expect(alerts).toHaveLength(1);
-  expect(text).toContain("Arsenal <b>62%</b>");
-  expect(text).toContain("Ayaan &amp; Co");
+  expect(content.text).toContain("Arsenal vs Coventry City");
+  expect(content.text).toContain("62%");
+  expect(content.text).toContain("Ayaan & Co");
   expect(deliveries).toHaveLength(1);
   expect(fixtureRow?.["alert_time"]).toBe(Math.floor(new Date("2026-09-01T12:00:00Z").getTime() / 1_000));
 });

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@libsql/client";
+import { Predicate } from "effect";
 import { Application, Effect, type Update } from "telly";
 import { FakeBotApi, FakeBotApiReply } from "telly/testing";
 
@@ -93,6 +94,22 @@ export function openRouterEmbeddings(requestBody: string): Response {
     model: "qwen/qwen3-embedding-8b",
     object: "list",
   }), { headers: { "content-type": "application/json" } });
+}
+
+export function richContent(params: unknown): {
+  readonly text: string;
+  readonly types: ReadonlyArray<string>;
+} {
+  const types: Array<string> = [];
+  const read = (value: unknown): ReadonlyArray<string> => {
+    if (typeof value === "string") return [value];
+    if (Array.isArray(value)) return value.flatMap(read);
+    if (!Predicate.isObject(value)) return [];
+    if (typeof value["type"] === "string") types.push(value["type"]);
+    return ["text", "summary", "blocks", "items", "cells"].flatMap((key) => read(value[key]));
+  };
+  const richMessage = Predicate.isObject(params) ? params["rich_message"] : undefined;
+  return { text: read(richMessage).join("\n"), types };
 }
 
 export async function fixture(

--- a/tests/information.test.ts
+++ b/tests/information.test.ts
@@ -6,6 +6,7 @@ import type { Fetch } from "../src/app/http.ts";
 import {
   commandUpdate,
   fixture,
+  richContent,
   testConfig,
 } from "./harness.ts";
 
@@ -29,11 +30,11 @@ test("define command renders the first dictionary meaning", async () => {
     database.close();
   }
 
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
-  expect(reply?.params).toMatchObject({
-    parse_mode: "HTML",
-    text: "<b>posthumous</b>\n🗣️ /ˈpɒstjʊməs/\n\n<b>adjective</b>\n  -  Existing after death.\n\nSynonyms:\n  - late\n  - postmortem",
-  });
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("Existing after death.");
+  expect(content.text).toContain("late");
+  expect(content.types).toContain("details");
 });
 
 test("Urban Dictionary command selects the highest-voted definition", async () => {
@@ -64,13 +65,11 @@ test("Urban Dictionary command selects the highest-voted definition", async () =
     database.close();
   }
 
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
-  expect(reply?.params).toMatchObject({
-    text: expect.stringContaining("strong definition"),
-  });
-  expect(reply?.params).not.toMatchObject({
-    text: expect.stringContaining("weak definition"),
-  });
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("strong definition");
+  expect(content.text).not.toContain("weak definition");
+  expect(content.types).toContain("blockquote");
 });
 
 test("calculation command explains an unrecognized query", async () => {
@@ -154,10 +153,10 @@ test("weather command stores the resolved location and renders air quality", asy
   ));
   database.close();
 
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
   expect(cached?.["address"]).toBe("Berlin, Berlin, Germany");
   expect(cached?.["latitude"]).toBe(52.52);
-  expect(reply?.params).toMatchObject({
-    text: expect.stringContaining("🛰 <b>AQI:</b> 42"),
-  });
+  expect(content.text).toContain("AQI\n42");
+  expect(content.types).toContain("table");
 });

--- a/tests/moderation.test.ts
+++ b/tests/moderation.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "telly";
 import { FakeBotApiReply } from "telly/testing";
 
 import type { Fetch } from "../src/app/http.ts";
-import { commandUpdate, fixture } from "./harness.ts";
+import { commandUpdate, fixture, richContent } from "./harness.ts";
 
 const offline: Fetch = async () => new Response("{}");
 const presence = () => [FakeBotApiReply.ok(true), FakeBotApiReply.ok(true)] as const;
@@ -28,6 +28,26 @@ test("block command prevents the selected user from using one command", async ()
   expect(reply?.params).toMatchObject({
     text: "✅ User <code>77</code> blocked from using /weather",
   });
+});
+
+test("blocklist presents moderation records in a native rich table", async () => {
+  const { app, bot, database, fake } = await fixture(offline, presence());
+  await Effect.runPromise(database.execute(
+    "INSERT INTO command_blocklist (user_id, command, blocked_by) VALUES (?, ?, ?)",
+    [77, "weather", 1],
+  ));
+
+  try {
+    await app.run(bot.handler(commandUpdate("/blocklist", 304)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("77\n/weather\n1");
+  expect(content.types).toContain("table");
 });
 
 test("unblock command reports when no matching block exists", async () => {

--- a/tests/reminders.test.ts
+++ b/tests/reminders.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "telly";
 import { FakeBotApiReply } from "telly/testing";
 
 import type { Fetch } from "../src/app/http.ts";
-import { commandUpdate, fixture } from "./harness.ts";
+import { commandUpdate, fixture, richContent } from "./harness.ts";
 
 const offline: Fetch = async () => new Response("{}");
 
@@ -25,8 +25,10 @@ test("remind command parses relative time and preserves the title", async () => 
 
   expect(row?.["title"]).toBe("Make tea");
   expect(row?.["target_time"]).toBe(1_788_271_200);
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
-  expect(reply?.params).toMatchObject({ text: expect.stringContaining("Make tea") });
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("Make tea");
+  expect(content.types).toContain("date_time");
 });
 
 test("reminder worker sends and removes each claimed reminder", async () => {

--- a/tests/rich.test.ts
+++ b/tests/rich.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { Application, BotApiError } from "telly";
 import { FakeBotApi, FakeBotApiReply } from "telly/testing";
 
-import { replyRich, richMessageLimit } from "../src/app/rich.ts";
+import { replyBlocks, replyRich, rich, richMessageLimit } from "../src/app/rich.ts";
 import { commandUpdate, sentMessage, token } from "./harness.ts";
 
 function sourceMessage() {
@@ -71,4 +71,26 @@ test("rich reply sends text beyond Telegram's rich limit as a document", async (
     fileName: "long-answer.txt",
     size: richMessageLimit + 1,
   });
+});
+
+test("rich blocks preserve group replies, private responses, and keyboards", async () => {
+  const fake = FakeBotApi.make({ token });
+  const app = Application.make({ httpClient: fake.layer, rateLimit: false, token });
+  const group = sourceMessage();
+  const direct = { ...group, chat: { id: 77, type: "private" as const } };
+  const replyMarkup = { inlineKeyboard: [[{ callbackData: "open", text: "Open" }]] };
+
+  try {
+    await app.run(replyBlocks(group, [rich.heading("Group result")], { replyMarkup }));
+    await app.run(replyBlocks(direct, [rich.heading("Private result")]));
+  } finally {
+    await app.close();
+  }
+
+  expect(fake.requests[0]?.params).toMatchObject({
+    reply_markup: { inline_keyboard: [[{ callback_data: "open", text: "Open" }]] },
+    reply_parameters: { message_id: group.messageId },
+    rich_message: { blocks: [{ text: "Group result", type: "heading" }] },
+  });
+  expect(fake.requests[1]?.params).not.toHaveProperty("reply_parameters");
 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -10,7 +10,7 @@ import {
   scheduleRuntimeJobs,
   waitForWebhook,
 } from "../src/runtime.ts";
-import { fixture, testConfig, token } from "./harness.ts";
+import { commandUpdate, fixture, richContent, testConfig, token } from "./harness.ts";
 
 const offline: Fetch = async () => new Response("{}");
 
@@ -40,6 +40,23 @@ test("bot registers every migrated command name", async () => {
     "thinking", "tl", "tldr", "tldw", "tr", "ud", "unblock", "unwhitelist", "users",
     "userstats", "ustat", "ustats", "video", "w", "weather", "whitelist",
   ]);
+});
+
+test("help presents enabled commands as a native rich list", async () => {
+  const { app, bot, database, fake } = await fixture(offline);
+
+  try {
+    await app.run(bot.handler(commandUpdate("/help", 7_001)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("/ping");
+  expect(content.text).toContain("Pong.");
+  expect(content.types).toContain("list");
 });
 
 test("runtime registers every recurring worker", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3,7 +3,7 @@ import { Effect, type Update } from "telly";
 import { FakeBotApiReply } from "telly/testing";
 
 import type { Fetch } from "../src/app/http.ts";
-import { commandUpdate, fixture } from "./harness.ts";
+import { commandUpdate, fixture, richContent } from "./harness.ts";
 
 const offline: Fetch = async () => new Response("{}");
 const presence = () => [FakeBotApiReply.ok(true), FakeBotApiReply.ok(true)] as const;
@@ -34,12 +34,29 @@ test("model command updates every AI model in one database write", async () => {
   expect(reply?.params).toMatchObject({ text: expect.stringContaining("All command models") });
 });
 
+test("model command presents configured models in a native rich table", async () => {
+  const { app, bot, database, fake } = await fixture(offline, presence());
+
+  try {
+    await app.run(bot.handler(commandUpdate("/model", 604)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("/ask");
+  expect(content.text).toContain("openrouter/x-ai/grok-4.3");
+  expect(content.types).toContain("table");
+});
+
 test("settings callback toggles message search and redraws the keyboard", async () => {
   const { app, bot, database, fake } = await fixture(offline, presence());
 
   try {
     await app.run(bot.handler(commandUpdate("/settings", 602)));
-    const sent = fake.requests.find((request) => request.method === "sendMessage");
+    const sent = fake.requests.find((request) => request.method === "sendRichMessage");
     if (typeof sent?.params !== "object" || sent.params === null) {
       throw new Error("Settings command sent no parameters");
     }
@@ -95,4 +112,5 @@ test("settings callback toggles message search and redraws the keyboard", async 
   expect(Reflect.get(edit.params, "chat_id")).toBe(-1007);
   expect(Reflect.get(edit.params, "message_id")).toBe(91);
   expect(firstText).toBe("On - Message search");
+  expect(richContent(edit.params).text).toContain("Group settings");
 });

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -3,7 +3,7 @@ import { Effect, type Update } from "telly";
 import { FakeBotApiReply } from "telly/testing";
 
 import type { Fetch } from "../src/app/http.ts";
-import { commandUpdate, fixture } from "./harness.ts";
+import { commandUpdate, fixture, richContent } from "./harness.ts";
 
 const offline: Fetch = async () => new Response("{}");
 
@@ -78,12 +78,11 @@ test("group stats ranks members by their message share", async () => {
     database.close();
   }
 
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
-  const text = typeof reply?.params === "object" && reply.params !== null
-    ? Reflect.get(reply.params, "text")
-    : undefined;
-  expect(text).toContain("66.7% - Ayaan");
-  expect(text).toContain("33.3% - Alice");
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("Ayaan\n2\n66.7%");
+  expect(content.text).toContain("Alice\n1\n33.3%");
+  expect(content.types).toContain("table");
 });
 
 test("friends command renders incoming and outgoing social edges", async () => {
@@ -106,10 +105,9 @@ test("friends command renders incoming and outgoing social edges", async () => {
     database.close();
   }
 
-  const reply = fake.requests.find((request) => request.method === "sendMessage");
-  const text = typeof reply?.params === "object" && reply.params !== null
-    ? Reflect.get(reply.params, "text")
-    : undefined;
-  expect(text).toContain("2 ⟶ Alice");
-  expect(text).toContain("1 ← Bob");
+  const reply = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(reply?.params);
+  expect(content.text).toContain("You →\nAlice\n2");
+  expect(content.text).toContain("You ←\nBob\n1");
+  expect(content.types).toContain("table");
 });


### PR DESCRIPTION
## Summary

- render substantial static command results with Telegram-native headings, tables, lists, details, charts, dates, links, and footers
- add one typed rich-block builder seam without creating a second document model
- preserve existing callback keyboards and group reply behavior
- keep compact errors, progress updates, and confirmations as plain messages

## Converted surfaces

- help, model, thinking, settings, usage
- group, command, user, and social stats
- dictionary, Urban Dictionary, and weather
- reminders, scheduled AI task listings, blocklist, football odds, and kickoff alerts

## Proof

- `bun run check`: 73 tests pass
- mutation check: model and help tests fail when rich blocks are dropped
- Telegram Test Server group proof: four native rich messages with 51 recorded events
- Telegram rendered `pageBlockList`, `pageBlockTable`, `pageBlockParagraph`, `pageBlockSectionHeading`, and `pageBlockFooter`
- settings retained its inline keyboard