### PR TITLE
fix(video): make generation model configurable

### DIFF
--- a/src/app/ai.ts
+++ b/src/app/ai.ts
@@ -208,23 +208,27 @@ export class Ai {
       readonly firstFrame?: string;
     },
   ) {
-    return Effect.tryPromise({
-      try: (signal) => generateVideo({
-        abortSignal: signal,
-        aspectRatio: options.aspectRatio,
-        download: ({ url, abortSignal }) => this.downloadVideo(url, abortSignal),
-        duration: 5,
-        model: this.provider().videoModel("bytedance/seedance-2.0-mini", {
-          extraBody: { resolution: "480p" },
-          generateAudio: true,
-          maxPollTimeMs: 15 * 60_000,
+    return getModel(this.dependencies, "video").pipe(
+      Effect.flatMap((model) => Effect.tryPromise({
+        try: (signal) => generateVideo({
+          abortSignal: signal,
+          aspectRatio: options.aspectRatio,
+          download: ({ url, abortSignal }) => this.downloadVideo(url, abortSignal),
+          duration: 5,
+          model: this.provider().videoModel(normalizeModelName(model), {
+            extraBody: { resolution: "480p" },
+            generateAudio: true,
+            maxPollTimeMs: 15 * 60_000,
+          }),
+          prompt: options.firstFrame === undefined
+            ? prompt
+            : { image: options.firstFrame, text: prompt },
         }),
-        prompt: options.firstFrame === undefined
-          ? prompt
-          : { image: options.firstFrame, text: prompt },
-      }),
-      catch: (error) => failure("video", error),
-    }).pipe(Effect.map((result) => result.video.uint8Array));
+        catch: (error) => failure("video", error),
+      })),
+      Effect.map((result) => result.video.uint8Array),
+      Effect.mapError((error) => failure("video", error)),
+    );
   }
 
   embeddings(inputs: ReadonlyArray<string>, dimensions: number) {

--- a/src/app/schema.ts
+++ b/src/app/schema.ts
@@ -57,7 +57,8 @@ const statements = [
     auto_dl INTEGER NOT NULL DEFAULT 0,
     search_model TEXT,
     cron_model TEXT,
-    song_model TEXT
+    song_model TEXT,
+    video_model TEXT
   )`,
   `CREATE TABLE IF NOT EXISTS user_stats (
     user_id INTEGER PRIMARY KEY,
@@ -365,6 +366,11 @@ export function initializeDatabase(database: Database) {
       if (!names.has(name)) yield* database.execute(
         `ALTER TABLE cron_tasks ADD COLUMN ${name} ${definition}`,
       );
+    }
+    const groupSettingColumns = yield* database.all("PRAGMA table_info(group_settings)");
+    const groupSettingNames = new Set(groupSettingColumns.map((row) => row["name"]));
+    if (!groupSettingNames.has("video_model")) {
+      yield* database.execute("ALTER TABLE group_settings ADD COLUMN video_model TEXT");
     }
   });
 }

--- a/src/features/settings.ts
+++ b/src/features/settings.ts
@@ -27,6 +27,7 @@ export const defaultModels = {
   song: "openrouter/x-ai/grok-4.3",
   tldr: "openrouter/google/gemini-3-flash-preview",
   tr: "google/gemini-2.5-flash",
+  video: "openrouter/bytedance/seedance-2.0-mini",
 } as const;
 
 export type ModelCommand = keyof typeof defaultModels;
@@ -40,6 +41,7 @@ const modelColumns: Readonly<Record<ModelCommand, string>> = {
   song: "song_model",
   tldr: "tldr_model",
   tr: "tr_model",
+  video: "video_model",
 };
 const thinkingLevels = ["none", "minimal", "low", "medium", "high"] as const;
 
@@ -89,7 +91,7 @@ export function getThinking(dependencies: AppDependencies) {
 
 function modelCommand(dependencies: AppDependencies): CommandDefinition {
   return {
-    description: "Set AI models for commands: ask, cron, edit, search, song, tr, tldr.",
+    description: `Set AI models for commands: ${modelCommands.join(", ")}.`,
     example: "/model ask openrouter/x-ai/grok-4.3",
     names: ["model"],
     run: Effect.fn("modelSettings")(function* (match) {
@@ -123,7 +125,7 @@ function modelCommand(dependencies: AppDependencies): CommandDefinition {
       if (targets.length === 0 || nextModel.length === 0) {
         return yield* answer(
           match.message,
-          "❌ Specify a valid command and model name. Commands: ask, cron, edit, search, song, tr, tldr, all",
+          `❌ Specify a valid command and model name. Commands: ${modelCommands.join(", ")}, all`,
         );
       }
       const columns = targets.map((target) => modelColumns[target]);

--- a/tests/automation.test.ts
+++ b/tests/automation.test.ts
@@ -161,9 +161,11 @@ test("song command delivers both generated tracks", async () => {
 });
 
 test("video command delivers the completed generated video", async () => {
+  let submitted: Record<string, unknown> = {};
   const send: Fetch = async (input, init) => {
     const url = String(input);
     if (url.endsWith("/videos") && init?.method === "POST") {
+      submitted = JSON.parse(String(init.body));
       return new Response(JSON.stringify({
         id: "video-job-9",
         polling_url: "https://openrouter.ai/api/v1/videos/video-job-9",
@@ -192,6 +194,10 @@ test("video command delivers the completed generated video", async () => {
     FakeBotApiReply.ok(true),
   ], config);
   await allow(database, "video");
+  await Effect.runPromise(database.execute(
+    "INSERT INTO group_settings (chat_id, video_model) VALUES (-1, ?)",
+    ["openrouter/bytedance/seedance-configured"],
+  ));
 
   try {
     await app.run(bot.handler(commandUpdate("/video a corgi on a glassy wave", 2_004)));
@@ -207,6 +213,7 @@ test("video command delivers the completed generated video", async () => {
     caption: expect.stringContaining("a corgi on a glassy wave"),
     chat_id: "-1007",
   });
+  expect(submitted["model"]).toBe("bytedance/seedance-configured");
 });
 
 test("video command downloads and frames a replied photo", async () => {

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -38,7 +38,7 @@ test("database from all 33 Python migrations preserves rows during TypeScript in
     [9],
   ));
   const setting = await Effect.runPromise(database.one(
-    "SELECT fts, auto_dl, search_model FROM group_settings WHERE chat_id = ?",
+    "SELECT fts, auto_dl, search_model, video_model FROM group_settings WHERE chat_id = ?",
     [-1007],
   ));
   const cronColumns = await Effect.runPromise(database.all("PRAGMA table_info(cron_tasks)"));
@@ -53,6 +53,7 @@ test("database from all 33 Python migrations preserves rows during TypeScript in
     auto_dl: 1,
     fts: 1,
     search_model: "openrouter/google/gemini-3-flash-preview",
+    video_model: null,
   });
   expect(cronColumns.map((row) => row["name"])).toEqual(expect.arrayContaining([
     "next_run_time",

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -18,7 +18,7 @@ test("model command updates every AI model in one database write", async () => {
   }
   const row = await Effect.runPromise(database.one(
     `SELECT ask_model, cron_model, edit_model, search_model,
-            song_model, tr_model, tldr_model
+            song_model, tr_model, tldr_model, video_model
      FROM group_settings WHERE chat_id = -1`,
   ));
   database.close();
@@ -30,8 +30,30 @@ test("model command updates every AI model in one database write", async () => {
   expect(row?.["song_model"]).toBe("openrouter/test/model");
   expect(row?.["tr_model"]).toBe("openrouter/test/model");
   expect(row?.["tldr_model"]).toBe("openrouter/test/model");
+  expect(row?.["video_model"]).toBe("openrouter/test/model");
   const reply = fake.requests.find((request) => request.method === "sendMessage");
   expect(reply?.params).toMatchObject({ text: expect.stringContaining("All command models") });
+});
+
+test("model command configures video generation", async () => {
+  const { app, bot, database, fake } = await fixture(offline, presence());
+
+  try {
+    await app.run(bot.handler(commandUpdate(
+      "/model video openrouter/bytedance/seedance-test",
+      605,
+    )));
+  } finally {
+    await app.close();
+  }
+  const row = await Effect.runPromise(database.one(
+    "SELECT video_model FROM group_settings WHERE chat_id = -1",
+  ));
+  database.close();
+
+  expect(row?.["video_model"]).toBe("openrouter/bytedance/seedance-test");
+  const reply = fake.requests.find((request) => request.method === "sendMessage");
+  expect(reply?.params).toMatchObject({ text: expect.stringContaining("Model for <b>/video</b>") });
 });
 
 test("model command presents configured models in a native rich table", async () => {


### PR DESCRIPTION
## Summary
- add `/video` to `/model` and `/model all`
- use the configured model for OpenRouter video generation
- migrate existing TypeScript-era databases without losing settings

## Validation
- `bun run check`
- 74 tests passed
- regression test fails when video generation is switched back to the hardcoded model