### PR TITLE
fix(ai): prevent prices from rendering as math

### DIFF
--- a/src/app/rich.ts
+++ b/src/app/rich.ts
@@ -22,6 +22,7 @@ export const richMessageLimit = 32_768;
 
 export const richMarkdownPrompt = `Format the user-visible answer as Telegram Rich Markdown.
 Use GitHub-flavored Markdown headings, lists, task lists, blockquotes, fenced code, tables, links, dividers, footnotes, and math when useful. Use ==text== for highlighting and ||text|| for spoilers.
+Write prices with ISO currency codes such as USD 48,500, never with dollar symbols. Use $...$ only for intentional mathematical expressions.
 Return only the answer without an outer code fence. Do not emit HTML, media, or buttons. Keep the answer under 32,768 characters.`;
 
 interface RichOptions {

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -33,7 +33,9 @@ test("ask command streams the OpenRouter answer into Telegram", async () => {
     expect(body.stream).toBe(true);
     expect(body.plugins).toEqual([{ engine: "native", id: "web", max_results: 20 }]);
     expect(body.reasoning).toEqual({ effort: "high" });
-    expect(JSON.stringify(body.messages)).toContain("Telegram Rich Markdown");
+    const messages = JSON.stringify(body.messages);
+    expect(messages).toContain("Telegram Rich Markdown");
+    expect(messages).toContain("Write prices with ISO currency codes such as USD 48,500");
     return openRouterStream("Hello from AI");
   };
   const { app, bot, database, fake } = await fixture(send, [], aiConfig());


### PR DESCRIPTION
## Summary
- reserve rich Markdown dollar delimiters for intentional mathematics
- require ISO currency codes such as `USD 48,500` in normal AI prose
- verify the rule reaches the model request

## Validation
- `bun run check`
- 75 tests passed
- regression assertion was proven red before the prompt fix