### PR TITLE
fix(football): retain odds from mixed Polymarket results

### DIFF
--- a/src/features/football.ts
+++ b/src/features/football.ts
@@ -60,17 +60,17 @@ const Summary = Schema.Struct({
 const Market = Schema.Struct({
   active: Schema.Boolean,
   closed: Schema.Boolean,
-  outcomePrices: Schema.String,
+  outcomePrices: Schema.optionalKey(Schema.String),
   outcomes: Schema.String,
   question: Schema.String,
-  sportsMarketType: Schema.String,
+  sportsMarketType: Schema.optionalKey(Schema.String),
 });
 const Polymarket = Schema.Struct({
   events: Schema.Array(Schema.Struct({
     active: Schema.Boolean,
     closed: Schema.Boolean,
     endDate: Schema.String,
-    eventDate: Schema.String,
+    eventDate: Schema.optionalKey(Schema.String),
     id: Schema.Union([Schema.String, Schema.Number]),
     markets: Schema.Array(Market),
     slug: Schema.String,
@@ -254,6 +254,7 @@ function hasTeam(text: string, team: string): boolean {
 }
 
 function yesPrice(market: typeof Market.Type): number | undefined {
+  if (market.outcomePrices === undefined) return undefined;
   const outcomes = Schema.decodeUnknownSync(Schema.Array(Schema.String))(JSON.parse(market.outcomes));
   const prices = Schema.decodeUnknownSync(Schema.Array(Schema.String))(JSON.parse(market.outcomePrices));
   const index = outcomes.indexOf("Yes");

--- a/tests/football.test.ts
+++ b/tests/football.test.ts
@@ -130,6 +130,80 @@ test("next command renders odds and a matching watch link", async () => {
   expect(content.types).toContain("table");
 });
 
+test("next command keeps match odds when search also returns season markets", async () => {
+  const response = {
+    events: [
+      ...polymarket().events,
+      {
+        active: true,
+        closed: false,
+        endDate: "2027-07-01T00:00:00Z",
+        id: "season-market",
+        markets: [
+          {
+            active: true,
+            closed: false,
+            outcomePrices: '["0.35", "0.65"]',
+            outcomes: '["Yes", "No"]',
+            question: "Will Arsenal win the 2026-27 Premier League?",
+          },
+          {
+            active: false,
+            closed: false,
+            outcomes: '["Yes", "No"]',
+            question: "Will another team win the 2026-27 Premier League?",
+          },
+        ],
+        slug: "epl-2027-champion",
+        title: "EPL: 2027 Champion",
+      },
+    ],
+  };
+  const send: Fetch = async (input) => String(input).includes("polymarket")
+    ? new Response(JSON.stringify(response))
+    : new Response("");
+  const { app, bot, database, fake } = await fixture(send);
+  await storeFixture(database);
+
+  try {
+    await app.run(bot.handler(commandUpdate("/next", 4_005)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const message = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(message?.params);
+  expect(content.text).toContain("62%\n23%\n15%");
+  expect(content.text).not.toContain("Pending");
+});
+
+test("next command leaves odds pending when a match market has no price", async () => {
+  const response = polymarket();
+  const { outcomePrices, ...unpriced } = response.events[0]!.markets[0]!;
+  const send: Fetch = async (input) => String(input).includes("polymarket")
+    ? new Response(JSON.stringify({
+        events: [{
+          ...response.events[0],
+          markets: [unpriced, ...response.events[0]!.markets.slice(1)],
+        }],
+      }))
+    : new Response("");
+  const { app, bot, database, fake } = await fixture(send);
+  await storeFixture(database);
+
+  try {
+    await app.run(bot.handler(commandUpdate("/next", 4_006)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const message = fake.requests.find((request) => request.method === "sendRichMessage");
+  const content = richContent(message?.params);
+  expect(content.text).toContain("Arsenal vs Coventry City\n—\n—\n—\nPending");
+});
+
 test("football buttons join and leave the current group", async () => {
   const offline: Fetch = async () => new Response("{}");
   const { app, bot, database, fake } = await fixture(offline);


### PR DESCRIPTION
Polymarket search returns match markets alongside season markets that omit `eventDate`, `sportsMarketType`, or `outcomePrices`. The parser required all three fields and discarded the whole response, so football alerts and `/next` showed Pending despite available match odds.

Match the response contract by accepting these optional fields, and leave genuinely unpriced matches pending. Add regression coverage for mixed search results and missing prices.

Validation: `bun run check` passed all 79 tests. Both regressions were observed failing before their corresponding fixes. Replayed the captured Manchester City–Coventry and Nottingham Forest–Tottenham responses through `/next`, then verified the rich odds table through a leased Telegram Test Server bot and recorded user-message timeline.
