### PR TITLE
refactor: remove redundant bot plumbing

### DIFF
--- a/src/app/ai.ts
+++ b/src/app/ai.ts
@@ -31,7 +31,6 @@ interface GenerateOptions {
   readonly extraBody?: Readonly<Record<string, unknown>>;
   readonly maxTokens?: number;
   readonly model?: string;
-  readonly temperature?: number;
 }
 
 export interface AiStream {
@@ -111,7 +110,6 @@ export class Ai {
           ...(options.maxTokens === undefined ? {} : { maxOutputTokens: options.maxTokens }),
           ...prompt(messages),
           model: this.languageModel(command, model, options, reasoning),
-          ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
         }),
         catch: (error) => failure("complete", error),
       })),
@@ -136,7 +134,6 @@ export class Ai {
             name: `${command}_response`,
             schema: standardSchema(schema),
           }),
-          ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
         }),
         catch: (error) => failure("object", error),
       })),
@@ -162,7 +159,6 @@ export class Ai {
             onError: ({ error }) => {
               streamFailure = { error };
             },
-            ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
           });
           const iterator = result.textStream[Symbol.asyncIterator]();
           return {

--- a/src/app/audio.ts
+++ b/src/app/audio.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { Effect, Schema } from "telly";
 
-export class AudioConversionError extends Schema.TaggedError<AudioConversionError>()(
+class AudioConversionError extends Schema.TaggedError<AudioConversionError>()(
   "AudioConversionError",
   { description: Schema.String },
 ) {}

--- a/src/app/command.ts
+++ b/src/app/command.ts
@@ -160,25 +160,6 @@ function recordCommand(
   );
 }
 
-function consumeQuota(
-  definition: CommandDefinition,
-  dependencies: AppDependencies,
-  match: CommandMatch,
-) {
-  const user = match.message.from;
-  if (
-    definition.dailyLimit === undefined ||
-    user === undefined ||
-    isAdmin(dependencies, user.id)
-  ) return Effect.succeed(true);
-  return useCommandQuota(
-    dependencies,
-    match.message,
-    commandName(match),
-    definition.dailyLimit,
-  );
-}
-
 export function useCommandQuota(
   dependencies: AppDependencies,
   message: Message,
@@ -238,7 +219,9 @@ export function commandHandlers(
           return yield* answer(match.message, "❌ You are blocked from using this command.");
         }
         if (!(yield* ensureAvailable(definition, dependencies, match))) return;
-        if (!(yield* consumeQuota(definition, dependencies, match))) return;
+        if (definition.dailyLimit !== undefined && !(yield* useCommandQuota(
+          dependencies, match.message, commandName(match), definition.dailyLimit,
+        ))) return;
         yield* commandPresence(match.message);
         return yield* definition.run(match);
       }).pipe(

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,4 +1,4 @@
-export type Updater = "polling" | "webhook";
+type Updater = "polling" | "webhook";
 
 export interface ApiConfig {
   readonly cobaltUrl?: string;

--- a/src/app/http.ts
+++ b/src/app/http.ts
@@ -5,17 +5,12 @@ export class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
   service: Schema.String,
 }) {}
 
-export interface JsonResponse<A> {
+interface HttpResponse<A> {
   readonly data: A;
   readonly status: number;
 }
 
-export interface TextResponse {
-  readonly data: string;
-  readonly status: number;
-}
-
-export interface BytesResponse {
+interface BytesResponse {
   readonly contentType?: string;
   readonly data: Uint8Array;
   readonly fileName?: string;
@@ -39,7 +34,7 @@ export class Http {
     url: string | URL,
     schema: Schema.Codec<A, unknown, never, never>,
     init?: RequestInit,
-  ): Effect.Effect<JsonResponse<A>, HttpError> {
+  ): Effect.Effect<HttpResponse<A>, HttpError> {
     return this.request(service, url, init).pipe(
       Effect.flatMap((response) =>
         Effect.tryPromise({
@@ -63,7 +58,7 @@ export class Http {
     service: string,
     url: string | URL,
     init?: RequestInit,
-  ): Effect.Effect<TextResponse, HttpError> {
+  ): Effect.Effect<HttpResponse<string>, HttpError> {
     return this.request(service, url, init).pipe(
       Effect.flatMap((response) =>
         Effect.tryPromise({
@@ -108,7 +103,7 @@ export class Http {
     );
   }
 
-  response(
+  private request(
     service: string,
     url: string | URL,
     init?: RequestInit,
@@ -117,13 +112,5 @@ export class Http {
       try: () => this.fetch(url, { ...init, signal: init?.signal ?? AbortSignal.timeout(60_000) }),
       catch: (error) => new HttpError({ description: errorDescription(error), service }),
     });
-  }
-
-  private request(
-    service: string,
-    url: string | URL,
-    init?: RequestInit,
-  ): Effect.Effect<Response, HttpError> {
-    return this.response(service, url, init);
   }
 }

--- a/src/app/links.ts
+++ b/src/app/links.ts
@@ -1,0 +1,5 @@
+export function messageLink(chatId: number, messageId: number, username?: string): string | undefined {
+  if (username !== undefined) return `https://t.me/${username}/${messageId}`;
+  const id = String(chatId);
+  return id.startsWith("-100") ? `https://t.me/c/${id.slice(4)}/${messageId}` : undefined;
+}

--- a/src/app/media.ts
+++ b/src/app/media.ts
@@ -12,14 +12,6 @@ export interface ImageData {
   readonly mimeType: string;
 }
 
-function mimeType(fileName: string | undefined, fallback: string): string {
-  const extension = fileName?.split(".").at(-1)?.toLowerCase();
-  if (extension === "png") return "image/png";
-  if (extension === "webp") return "image/webp";
-  if (extension === "jpg" || extension === "jpeg") return "image/jpeg";
-  return fallback;
-}
-
 export function messageImage(
   message: Message,
   allowDocument = false,
@@ -45,11 +37,9 @@ export function messageImage(
     media?.type === "document" &&
     media.document.mimeType?.startsWith("image/") === true
   ) {
+    const mimeType = media.document.mimeType;
     return downloadFile({ fileId: media.document.fileId }).pipe(
-      Effect.map((bytes) => ({
-        bytes,
-        mimeType: media.document.mimeType ?? mimeType(media.document.fileName, "image/jpeg"),
-      })),
+      Effect.map((bytes) => ({ bytes, mimeType })),
     );
   }
   return Effect.succeed(undefined);

--- a/src/app/rich.ts
+++ b/src/app/rich.ts
@@ -7,7 +7,6 @@ import {
   sendDocument,
   sendMessage,
   sendRichMessage,
-  type BotApiError,
   type ConversationMessage,
   type ConversationTarget,
   type InputRichBlock,
@@ -16,6 +15,8 @@ import {
   type ReplyTarget,
   type RichText,
 } from "telly";
+
+import { ignoreUnchangedMessage } from "./callback.ts";
 
 const plainMessageLimit = 4_096;
 export const richMessageLimit = 32_768;
@@ -142,19 +143,14 @@ export const sendRich = Effect.fn("sendRich")(function* (
   return yield* sendAt({ chatId }, text, options);
 });
 
-function notModified(error: BotApiError): boolean {
-  return error.reason._tag === "TelegramRejected" &&
-    error.reason.description.toLowerCase().includes("message is not modified");
-}
-
 export const editRich = Effect.fn("editRich")(function* (message: Message, text: string) {
   if (text.length <= richMessageLimit) {
-    const edited = yield* Effect.result(editMessageText({
+    const edited = yield* Effect.result(ignoreUnchangedMessage(editMessageText({
       chatId: message.chat.id,
       messageId: message.messageId,
       richMessage: { markdown: text },
-    }));
-    if (edited._tag === "Success" || notModified(edited.failure)) return;
+    })));
+    if (edited._tag === "Success") return;
     if (edited.failure.reason._tag !== "TelegramRejected") {
       return yield* Effect.fail(edited.failure);
     }

--- a/src/features/ask.ts
+++ b/src/features/ask.ts
@@ -150,12 +150,10 @@ function editCommand(ai: Ai): CommandDefinition {
       const requester = match.message.from?.username === undefined
         ? `User ${match.message.from?.id ?? "unknown"}`
         : `@${match.message.from.username}`;
-      const buffer = new ArrayBuffer(generated.byteLength);
-      new Uint8Array(buffer).set(generated);
       yield* sendPhoto({
         caption: `📝 Requested by ${requester}\n🎨 Prompt: ${match.argText}`,
         chatId: match.message.chat.id,
-        photo: new File([buffer], "generated.png", { type: "image/png" }),
+        photo: new File([new Uint8Array(generated)], "generated.png", { type: "image/png" }),
       });
     }),
     usage: "/edit [prompt]",

--- a/src/features/content.ts
+++ b/src/features/content.ts
@@ -40,7 +40,7 @@ function firstLink(message: Message): URL | undefined {
   return message.replyToMessage === undefined ? undefined : firstLink(message.replyToMessage);
 }
 
-export function youtubeVideoId(url: URL): string | undefined {
+function youtubeVideoId(url: URL): string | undefined {
   const host = url.hostname.replace(/^www\./u, "");
   if (host === "youtu.be") return url.pathname.slice(1).split("/", 1)[0] || undefined;
   if (!new Set([

--- a/src/features/download.ts
+++ b/src/features/download.ts
@@ -60,9 +60,7 @@ function sendBytes(
     Effect.flatMap((response) => {
       if (response.status !== 200) return Effect.fail(new Error("Media download failed"));
       const name = fileName ?? response.fileName ?? "file";
-      const buffer = new ArrayBuffer(response.data.byteLength);
-      new Uint8Array(buffer).set(response.data);
-      const file = new File([buffer], name, {
+      const file = new File([new Uint8Array(response.data)], name, {
         type: response.contentType ?? "application/octet-stream",
       });
       const lower = name.toLowerCase();

--- a/src/features/highlight.ts
+++ b/src/features/highlight.ts
@@ -18,6 +18,7 @@ import {
 import { callbackRoute, ignoreUnchangedMessage } from "../app/callback.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { messageLink } from "../app/links.ts";
 
 const HighlightCallback = callbackData("highlight", Schema.Struct({
   highlightId: Schema.Int,
@@ -47,12 +48,6 @@ function highlightKeyboard(
         : [[{ style: "primary" as const, text: "Start DM", url: `https://t.me/${botUsername}` }]]),
     ],
   })));
-}
-
-function messageLink(chatId: number, username: string | undefined, messageId: number): string {
-  if (username !== undefined) return `https://t.me/${username}/${messageId}`;
-  const value = String(chatId);
-  return value.startsWith("-100") ? `https://t.me/c/${value.slice(4)}/${messageId}` : "";
 }
 
 export function highlightFeature(dependencies: AppDependencies) {
@@ -147,7 +142,7 @@ export function highlightFeature(dependencies: AppDependencies) {
             style: "danger",
           }]],
         },
-        text: `Your highlight <code>${html.escape(keyword)}</code> was mentioned in <b>${html.escape(message.chat.title ?? String(message.chat.id))}</b> by <a href="tg://user?id=${sender.id}">${html.escape(sender.firstName)}</a>.\n\n🔗 <a href="${messageLink(message.chat.id, message.chat.username, message.messageId)}">Link</a>`,
+        text: `Your highlight <code>${html.escape(keyword)}</code> was mentioned in <b>${html.escape(message.chat.title ?? String(message.chat.id))}</b> by <a href="tg://user?id=${sender.id}">${html.escape(sender.firstName)}</a>.\n\n🔗 <a href="${messageLink(message.chat.id, message.messageId, message.chat.username) ?? ""}">Link</a>`,
       }));
     }
   }, Effect.catch((error) => Effect.logError("Highlight worker failed").pipe(

--- a/src/features/reminders.ts
+++ b/src/features/reminders.ts
@@ -17,7 +17,7 @@ import { replyBlocks, rich } from "../app/rich.ts";
 const claimLeaseSeconds = 5 * 60;
 const maximumAttempts = 5;
 
-export function parseReminderTime(text: string, now: Date): Date | undefined {
+function parseReminderTime(text: string, now: Date): Date | undefined {
   const hasIst = /\bIST\b/iu.test(text);
   const normalized = text.replace(/\bIST\b/giu, "").trim();
   return parseDate(

--- a/src/features/search.ts
+++ b/src/features/search.ts
@@ -1,3 +1,4 @@
+import { chunksOf, lastNonEmpty } from "effect/Array";
 import {
   deleteMessage,
   downloadFile,
@@ -15,6 +16,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { messageLink } from "../app/links.ts";
 import { replyRich } from "../app/rich.ts";
 import { getModel, normalizeModelName } from "./settings.ts";
 
@@ -99,24 +101,17 @@ export function buildWindows(messages: ReadonlyArray<SourceMessage>): ReadonlyAr
 }
 
 export function buildUtterances(messages: ReadonlyArray<SourceMessage>): ReadonlyArray<SearchWindow & { readonly userId: number; readonly author: string }> {
-  const groups: Array<Array<SourceMessage>> = [];
-  let current: Array<SourceMessage> = [];
+  const groups: Array<[SourceMessage, ...Array<SourceMessage>]> = [];
   for (const message of messages) {
-    const previous = current.at(-1);
-    const gap = previous === undefined
-      ? 0
-      : new Date(message.createTime).getTime() - new Date(previous.createTime).getTime();
-    if (previous !== undefined && (previous.userId !== message.userId || gap > 300_000 || current.length === 12)) {
-      groups.push(current);
-      current = [];
-    }
-    current.push(message);
+    const current = groups.at(-1);
+    if (current === undefined || current[0].userId !== message.userId || current.length === 12 ||
+      new Date(message.createTime).getTime() - new Date(lastNonEmpty(current).createTime).getTime() > 300_000) {
+      groups.push([message]);
+    } else current.push(message);
   }
-  if (current.length > 0) groups.push(current);
   return groups.map((group) => {
     const first = group[0];
-    const last = group.at(-1);
-    if (first === undefined || last === undefined) throw new Error("Empty utterance group");
+    const last = lastNonEmpty(group);
     return {
       author: first.author,
       endMessageId: last.messageId,
@@ -153,10 +148,6 @@ function sourceMessages(dependencies: AppDependencies, chatId: number) {
   }))));
 }
 
-function vectorJson(values: ReadonlyArray<number>): string {
-  return JSON.stringify(values);
-}
-
 function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
   return Effect.gen(function* () {
     const messages = yield* sourceMessages(dependencies, chatId);
@@ -172,8 +163,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
        WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 256`,
       [chatId, embeddingModel],
     )).map((row) => `${rowNumber(row, "start_message_id")}:${rowNumber(row, "end_message_id")}`));
-    for (const batch of Array.from({ length: Math.ceil(windows.length / 64) }, (_, index) =>
-      windows.slice(index * 64, index * 64 + 64))) {
+    for (const batch of chunksOf(windows, 64)) {
       const missing = batch.filter((window) => !indexedWindows.has(`${window.startMessageId}:${window.endMessageId}`));
       if (missing.length === 0) continue;
       const embeddings = yield* ai.embeddings(missing.map((window) => window.text), 1_024);
@@ -191,7 +181,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
             window.endTime,
             window.messageCount,
             window.text,
-            vectorJson(embeddings[index] ?? []),
+            JSON.stringify(embeddings[index]!),
             embeddingModel,
           ],
         );
@@ -203,8 +193,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
         );
       }), { concurrency: 1, discard: true });
     }
-    for (const batch of Array.from({ length: Math.ceil(utterances.length / 64) }, (_, index) =>
-      utterances.slice(index * 64, index * 64 + 64))) {
+    for (const batch of chunksOf(utterances, 64)) {
       const missing = batch.filter((utterance) => !indexedUtterances.has(`${utterance.startMessageId}:${utterance.endMessageId}`));
       if (missing.length === 0) continue;
       const embeddings = yield* ai.embeddings(missing.map((item) => item.text), 256);
@@ -223,7 +212,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
           item.endTime,
           item.messageCount,
           item.text,
-          vectorJson(embeddings[index] ?? []),
+          JSON.stringify(embeddings[index]!),
           embeddingModel,
         ],
       ), { concurrency: 1, discard: true });
@@ -253,8 +242,8 @@ function evidenceFromWindows(
        )`}
      ORDER BY score DESC LIMIT 12`,
     authorId === undefined
-      ? [vectorJson(vector), chatId, embeddingModel]
-      : [vectorJson(vector), chatId, embeddingModel, authorId],
+      ? [JSON.stringify(vector), chatId, embeddingModel]
+      : [JSON.stringify(vector), chatId, embeddingModel, authorId],
   ).pipe(Effect.map((rows): ReadonlyArray<SearchEvidence> => rows.map((row) => ({
     citationMessageId: rowNumber(row, "end_message_id"),
     endMessageId: rowNumber(row, "end_message_id"),
@@ -281,11 +270,6 @@ export function selectEvidence(values: ReadonlyArray<SearchEvidence>): ReadonlyA
   return selected;
 }
 
-function messageLink(chatId: number, messageId: number): string | undefined {
-  const value = String(chatId);
-  return value.startsWith("-100") ? `https://t.me/c/${value.slice(4)}/${messageId}` : undefined;
-}
-
 export function renderSearchAnswer(
   output: typeof SearchAnswer.Type,
   evidence: ReadonlyArray<{ readonly citationMessageId: number }>,
@@ -295,12 +279,11 @@ export function renderSearchAnswer(
   const indexes = [...new Set(output.citations)];
   if (answer.length === 0 || answer === noAnswer || indexes.some((index) =>
     index < 1 || index > evidence.length)) return { answer: noAnswer, citations: [] };
-  const references = indexes.flatMap((index) => {
+  const citations = [...new Set(indexes.flatMap((index) => {
     const item = evidence[index - 1];
-    return item === undefined ? [] : [{ index, messageId: item.citationMessageId }];
-  }).filter((item, index, items) => items.findIndex((other) => other.messageId === item.messageId) === index);
-  const citations = references.map((item) => item.messageId);
-  const links = references.flatMap(({ messageId }, index) => {
+    return item === undefined ? [] : [item.citationMessageId];
+  }))];
+  const links = citations.flatMap((messageId, index) => {
     const link = messageLink(chatId, messageId);
     return link === undefined ? [] : [`[${index + 1}](${link})`];
   });
@@ -538,8 +521,7 @@ function importCommand(dependencies: AppDependencies): CommandDefinition {
         messageId: status.messageId,
         text: `Importing ${rows.length.toLocaleString()} messages...`,
       });
-      for (const batch of Array.from({ length: Math.ceil(rows.length / 200) }, (_, index) =>
-        rows.slice(index * 200, index * 200 + 200))) {
+      for (const batch of chunksOf(rows, 200)) {
         yield* dependencies.database.batch(batch.map(({ message, text, userId }) => ({
           args: [
             match.message.chat.id,

--- a/src/features/settings.ts
+++ b/src/features/settings.ts
@@ -19,7 +19,7 @@ import { rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
 import { replyBlocks, rich } from "../app/rich.ts";
 
-export const defaultModels = {
+const defaultModels = {
   ask: "openrouter/x-ai/grok-4.3",
   cron: "openrouter/x-ai/grok-4.3",
   edit: "openrouter/google/gemini-3.1-flash-image-preview",
@@ -33,29 +33,19 @@ export const defaultModels = {
 export type ModelCommand = keyof typeof defaultModels;
 
 const modelCommands = Object.keys(defaultModels) as ReadonlyArray<ModelCommand>;
-const modelColumns: Readonly<Record<ModelCommand, string>> = {
-  ask: "ask_model",
-  cron: "cron_model",
-  edit: "edit_model",
-  search: "search_model",
-  song: "song_model",
-  tldr: "tldr_model",
-  tr: "tr_model",
-  video: "video_model",
-};
 const thinkingLevels = ["none", "minimal", "low", "medium", "high"] as const;
 
 const toggleDefinitions = [
-  { key: "fts", label: "Message search", table: "group_settings", value: "fts" },
-  { key: "auto_dl", label: "Auto download", table: "group_settings", value: "auto_dl" },
-  { key: "ask", label: "/ask", table: "command_whitelist", value: "ask" },
-  { key: "edit", label: "/edit", table: "command_whitelist", value: "edit" },
-  { key: "video", label: "/video", table: "command_whitelist", value: "video" },
-  { key: "tr", label: "/tr", table: "command_whitelist", value: "tr" },
-  { key: "tldr", label: "/tldr", table: "command_whitelist", value: "tldr" },
-  { key: "search", label: "/search", table: "command_whitelist", value: "search" },
-  { key: "cron", label: "/cron", table: "command_whitelist", value: "cron" },
-  { key: "song", label: "/song", table: "command_whitelist", value: "song" },
+  { key: "fts", label: "Message search", table: "group_settings" },
+  { key: "auto_dl", label: "Auto download", table: "group_settings" },
+  { key: "ask", label: "/ask", table: "command_whitelist" },
+  { key: "edit", label: "/edit", table: "command_whitelist" },
+  { key: "video", label: "/video", table: "command_whitelist" },
+  { key: "tr", label: "/tr", table: "command_whitelist" },
+  { key: "tldr", label: "/tldr", table: "command_whitelist" },
+  { key: "search", label: "/search", table: "command_whitelist" },
+  { key: "cron", label: "/cron", table: "command_whitelist" },
+  { key: "song", label: "/song", table: "command_whitelist" },
 ] as const;
 
 type ToggleKey = (typeof toggleDefinitions)[number]["key"];
@@ -75,7 +65,7 @@ export function normalizeModelName(value: string): string {
 
 export function getModel(dependencies: AppDependencies, command: ModelCommand) {
   return dependencies.database.one(
-    `SELECT ${modelColumns[command]} AS model FROM group_settings WHERE chat_id = -1`,
+    `SELECT ${command}_model AS model FROM group_settings WHERE chat_id = -1`,
   ).pipe(Effect.map((row) => row === undefined || row["model"] === null
     ? defaultModels[command]
     : rowString(row, "model")));
@@ -128,7 +118,7 @@ function modelCommand(dependencies: AppDependencies): CommandDefinition {
           `❌ Specify a valid command and model name. Commands: ${modelCommands.join(", ")}, all`,
         );
       }
-      const columns = targets.map((target) => modelColumns[target]);
+      const columns = targets.map((target) => `${target}_model`);
       yield* dependencies.database.execute(
         `INSERT INTO group_settings (chat_id, ${columns.join(", ")})
          VALUES (-1, ${columns.map(() => "?").join(", ")})
@@ -191,43 +181,26 @@ function canManage(dependencies: AppDependencies, chatId: number, userId: number
 
 function settingStates(dependencies: AppDependencies, chatId: number) {
   return Effect.gen(function* () {
-    const states: Record<ToggleKey, boolean> = {
-      ask: false,
-      auto_dl: false,
-      cron: false,
-      edit: false,
-      fts: false,
-      search: false,
-      song: false,
-      tldr: false,
-      tr: false,
-      video: false,
-    };
     const setting = yield* dependencies.database.one(
       "SELECT fts, auto_dl FROM group_settings WHERE chat_id = ?",
       [chatId],
     );
-    states.fts = setting?.["fts"] === 1;
-    states.auto_dl = setting?.["auto_dl"] === 1;
     const rows = yield* dependencies.database.all(
       `SELECT command FROM command_whitelist
        WHERE whitelist_type = 'chat' AND whitelist_id = ?`,
       [chatId],
     );
-    for (const row of rows) {
-      const command = rowString(row, "command");
-      if (toggleDefinitions.some((toggle) => toggle.key === command)) {
-        states[command as ToggleKey] = true;
-      }
-    }
-    return states;
+    const commands = new Set(rows.map((row) => rowString(row, "command")));
+    return new Set(toggleDefinitions.filter((toggle) =>
+      (toggle.table === "group_settings" && setting?.[toggle.key] === 1) || commands.has(toggle.key)
+    ).map((toggle) => toggle.key));
   });
 }
 
-function keyboard(chatId: number, states: Readonly<Record<ToggleKey, boolean>>) {
+function keyboard(chatId: number, states: ReadonlySet<ToggleKey>) {
   return {
     inlineKeyboard: toggleDefinitions.map((toggle) => [SettingsCallback.button(
-      `${states[toggle.key] ? "On" : "Off"} - ${toggle.label}`,
+      `${states.has(toggle.key) ? "On" : "Off"} - ${toggle.label}`,
       { chatId, key: toggle.key },
     )]),
   };
@@ -268,8 +241,8 @@ function setToggle(dependencies: AppDependencies, chatId: number, key: ToggleKey
   if (toggle === undefined) return Effect.die(new Error(`Unknown setting: ${key}`));
   if (toggle.table === "group_settings") {
     return dependencies.database.execute(
-      `INSERT INTO group_settings (chat_id, ${toggle.value}) VALUES (?, ?)
-       ON CONFLICT(chat_id) DO UPDATE SET ${toggle.value} = excluded.${toggle.value}`,
+      `INSERT INTO group_settings (chat_id, ${toggle.key}) VALUES (?, ?)
+       ON CONFLICT(chat_id) DO UPDATE SET ${toggle.key} = excluded.${toggle.key}`,
       [chatId, enabled],
     );
   }
@@ -277,12 +250,12 @@ function setToggle(dependencies: AppDependencies, chatId: number, key: ToggleKey
     ? dependencies.database.execute(
         `INSERT OR IGNORE INTO command_whitelist (command, whitelist_type, whitelist_id)
          VALUES (?, 'chat', ?)`,
-        [toggle.value, chatId],
+        [toggle.key, chatId],
       )
     : dependencies.database.execute(
         `DELETE FROM command_whitelist
          WHERE command = ? AND whitelist_type = 'chat' AND whitelist_id = ?`,
-        [toggle.value, chatId],
+        [toggle.key, chatId],
       );
 }
 
@@ -301,7 +274,7 @@ export function settingsCallback(dependencies: AppDependencies) {
       });
     }
     const states = yield* settingStates(dependencies, data.chatId);
-    const enabled = !states[data.key];
+    const enabled = !states.has(data.key);
     yield* setToggle(dependencies, data.chatId, data.key, enabled);
     const next = yield* settingStates(dependencies, data.chatId);
     yield* answerCallback(callbackQuery, {

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -7,6 +7,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber, rowString } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { messageLink } from "../app/links.ts";
 import { replyBlocks, rich } from "../app/rich.ts";
 
 function readableTime(now: Date, input: string): string {
@@ -90,13 +91,8 @@ function seenCommand(dependencies: AppDependencies): CommandDefinition {
         return yield* answer(match.message, `@${username} has never been seen in this chat.`);
       }
       const messageId = rowNumber(row, "message_id");
-      const chatId = String(match.message.chat.id);
-      const messageLink = match.message.chat.username === undefined && chatId.startsWith("-100")
-        ? `https://t.me/c/${chatId.slice(4)}/${messageId}`
-        : match.message.chat.username === undefined
-        ? undefined
-        : `https://t.me/${match.message.chat.username}/${messageId}`;
-      const link = messageLink === undefined ? "" : `\n\n🔗 <a href="${messageLink}">Link</a>`;
+      const url = messageLink(match.message.chat.id, messageId, match.message.chat.username);
+      const link = url === undefined ? "" : `\n\n🔗 <a href="${url}">Link</a>`;
       return yield* answer(match.message, {
         linkPreviewOptions: { isDisabled: true },
         parseMode: "HTML",

--- a/src/features/storage.ts
+++ b/src/features/storage.ts
@@ -248,19 +248,14 @@ function quoteCommand(dependencies: AppDependencies): CommandDefinition {
         [match.message.chat.id, rowNumber(row, "id")],
       );
       const forwardedMessageId = row["forwarded_message_id"];
-      if (typeof forwardedMessageId !== "number") {
-        yield* dependencies.database.batch([
-          { sql: "DELETE FROM quote_recent_history WHERE quote_id = ?", args: [rowNumber(row, "id")] },
-          { sql: "DELETE FROM quote_db WHERE id = ?", args: [rowNumber(row, "id")] },
-        ]);
-        return yield* answer(match.message, "Quoted message deleted. Removing the quote.");
+      if (typeof forwardedMessageId === "number") {
+        const delivery = yield* Effect.result(forwardMessage({
+          chatId: match.message.chat.id,
+          fromChatId: dependencies.config.quoteChannelId,
+          messageId: forwardedMessageId,
+        }));
+        if (delivery._tag === "Success") return;
       }
-      const delivery = yield* Effect.result(forwardMessage({
-        chatId: match.message.chat.id,
-        fromChatId: dependencies.config.quoteChannelId,
-        messageId: forwardedMessageId,
-      }));
-      if (delivery._tag === "Success") return;
       yield* dependencies.database.batch([
         { sql: "DELETE FROM quote_recent_history WHERE quote_id = ?", args: [rowNumber(row, "id")] },
         { sql: "DELETE FROM quote_db WHERE id = ?", args: [rowNumber(row, "id")] },

--- a/src/features/tracking.ts
+++ b/src/features/tracking.ts
@@ -7,12 +7,7 @@ import {
 
 import { rowNumber } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
-
-function link(chatId: number, username: string | undefined, messageId: number): string | null {
-  if (username !== undefined) return `https://t.me/${username}/${messageId}`;
-  const id = String(chatId);
-  return id.startsWith("-100") ? `https://t.me/c/${id.slice(4)}/${messageId}` : null;
-}
+import { messageLink } from "../app/links.ts";
 
 function userIdForMention(dependencies: AppDependencies, username: string) {
   return dependencies.database.one(
@@ -81,7 +76,7 @@ export function trackingHandler(dependencies: AppDependencies): UpdateHandler<ne
           user.username,
           user.firstName,
           dependencies.now().toISOString(),
-          link(message.chat.id, message.chat.username, message.messageId),
+          messageLink(message.chat.id, message.messageId, message.chat.username) ?? null,
         ],
       );
     }

--- a/src/features/video.ts
+++ b/src/features/video.ts
@@ -101,8 +101,6 @@ export function videoCommand(dependencies: AppDependencies): CommandDefinition {
         }).pipe(Effect.as(undefined))));
         if (bytes === undefined) return;
         completed = true;
-        const buffer = new ArrayBuffer(bytes.byteLength);
-        new Uint8Array(buffer).set(bytes);
         const requester = match.message.from?.username === undefined
           ? `User ${match.message.from?.id ?? "unknown"}`
           : `@${match.message.from.username}`;
@@ -113,7 +111,7 @@ export function videoCommand(dependencies: AppDependencies): CommandDefinition {
           caption: `🎬 Requested by ${requester}\n📝 Prompt: ${prompt}`,
           chatId: match.message.chat.id,
           supportsStreaming: true,
-          video: new File([buffer], "seedance.mp4", { type: "video/mp4" }),
+          video: new File([new Uint8Array(bytes)], "seedance.mp4", { type: "video/mp4" }),
         }));
         if (delivered._tag === "Failure") {
           yield* editMessageText({

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -93,48 +93,21 @@ export function scheduleRuntimeJobs(
   app: Application,
   jobs: ReturnType<typeof runtimeJobs>,
 ) {
-  return Effect.all([
-    jobs.schedule("reminders", {
-      at: new Date("2026-01-01T00:00:00Z"),
-      every: "1 minute",
-      payload: {},
-    }),
-    jobs.schedule("cron", {
-      at: new Date("2026-01-01T00:00:00Z"),
-      every: "1 minute",
-      payload: {},
-    }),
-    jobs.schedule("footballAlerts", {
-      at: new Date("2026-01-01T00:00:00Z"),
-      every: "1 minute",
-      payload: {},
-    }),
-    jobs.schedule("footballSync", {
-      at: new Date("2026-01-01T03:00:00Z"),
-      every: "1 day",
-      payload: {},
-    }),
-    jobs.schedule("habit", {
-      at: new Date("2026-01-01T14:30:00Z"),
-      every: "1 day",
-      payload: {},
-    }),
-    jobs.schedule("quotas", {
-      at: new Date("2026-01-01T18:30:00Z"),
-      every: "1 day",
-      payload: {},
-    }),
-    jobs.schedule("searchIndex", {
-      at: new Date("2026-01-01T00:00:30Z"),
-      every: "15 minutes",
-      payload: {},
-    }),
-    jobs.schedule("searchMemory", {
-      at: new Date("2026-01-01T03:00:00Z"),
-      every: "1 day",
-      payload: {},
-    }),
-  ], { concurrency: "unbounded", discard: true }).pipe((effect) => app.run(effect));
+  const schedules = [
+    ["reminders", "00:00:00", "1 minute"],
+    ["cron", "00:00:00", "1 minute"],
+    ["footballAlerts", "00:00:00", "1 minute"],
+    ["footballSync", "03:00:00", "1 day"],
+    ["habit", "14:30:00", "1 day"],
+    ["quotas", "18:30:00", "1 day"],
+    ["searchIndex", "00:00:30", "15 minutes"],
+    ["searchMemory", "03:00:00", "1 day"],
+  ] as const;
+  return app.run(Effect.forEach(schedules, ([name, time, every]) => jobs.schedule(name, {
+    at: new Date(`2026-01-01T${time}Z`),
+    every,
+    payload: {},
+  }), { concurrency: "unbounded", discard: true }));
 }
 
 export function reportUpdateErrors(

--- a/tests/e2e/search.mjs
+++ b/tests/e2e/search.mjs
@@ -68,7 +68,7 @@ const result = await withTelegramRun(async (scope) => {
     ]));
     database.close();
     const ready = new Promise((resolveReady, reject) => {
-      child = spawn("bun", ["src/main.ts"], { cwd: repository, env: {
+      child = spawn("bun", [join(repository, "src", "main.ts")], { cwd: repository, env: {
         ...process.env, TELEGRAM_TOKEN: credential.sutToken, TELEGRAM_API_ROOT: proxy.apiRoot,
         ADMINS: credential.testerUserId, QUOTE_CHANNEL_ID: String(chatId), LOGGING_CHANNEL_ID: "",
         TURSO_DATABASE_URL: databaseUrl, TURSO_AUTH_TOKEN: "test", UPDATER: "polling",

--- a/tests/links.test.ts
+++ b/tests/links.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+import { messageLink } from "../src/app/links.ts";
+
+test("message links use a public username before the private supergroup address", () => {
+  expect(messageLink(-100123, 42, "public_group")).toBe("https://t.me/public_group/42");
+});
+
+test("private supergroup links retain the message id", () => {
+  expect(messageLink(-100123, 42)).toBe("https://t.me/c/123/42");
+});
+
+test("private chats and basic groups have no message permalink", () => {
+  expect(messageLink(123, 42)).toBeUndefined();
+  expect(messageLink(-123, 42)).toBeUndefined();
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -50,6 +50,24 @@ test("search windows overlap while utterances retain speaker ownership", () => {
   ]);
 });
 
+test("utterances keep the final message after a twelve-message group", () => {
+  const utterances = buildUtterances(messages(15).slice(2));
+  expect(utterances.map((item) => [item.startMessageId, item.endMessageId, item.messageCount])).toEqual([
+    [3, 14, 12],
+    [15, 15, 1],
+  ]);
+  expect(buildUtterances([])).toEqual([]);
+});
+
+test("utterances split only after a pause longer than five minutes", () => {
+  const utterances = buildUtterances([
+    { author: "@alice", userId: 1, messageId: 1, text: "first", createTime: "2026-09-07T10:00:00Z" },
+    { author: "@alice", userId: 1, messageId: 2, text: "second", createTime: "2026-09-07T10:05:00Z" },
+    { author: "@alice", userId: 1, messageId: 3, text: "third", createTime: "2026-09-07T10:10:01Z" },
+  ]);
+  expect(utterances.map((item) => item.text)).toEqual(["1 first\n2 second", "3 third"]);
+});
+
 test("search evidence removes overlaps and owns valid citation links", () => {
   const evidence = [
     { citationMessageId: 24, endMessageId: 24, endTime: "b", messageCount: 24, score: 0.8, startMessageId: 1, startTime: "a", text: "first" },

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -160,13 +160,21 @@ test("addquote rejects a protected replied message before forwarding", async () 
   });
 });
 
-test("quote removes a legacy row that has no archived message", async () => {
-  const { app, bot, database, fake } = await fixture(offline);
+for (const [reason, archivedMessageId] of [["missing archive id", null], ["rejected forwarding", 700]] as const)
+test(`quote removes an unavailable message after ${reason}`, async () => {
+  const { app, bot, database, fake } = await fixture(offline, [
+    FakeBotApiReply.ok(true),
+    FakeBotApiReply.ok(true),
+    ...(archivedMessageId === null ? [] : [FakeBotApiReply.reject({
+      description: "Bad Request: message to forward not found",
+      errorCode: 400,
+    })]),
+  ]);
   await Effect.runPromise(database.execute(
     `INSERT INTO quote_db (
       id, message_id, chat_id, message_user_id, saver_user_id, forwarded_message_id
-    ) VALUES (?, ?, ?, ?, ?, NULL)`,
-    [91, 501, -1007, 2, 1],
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [91, 501, -1007, 2, 1, archivedMessageId],
   ));
 
   try {
@@ -177,7 +185,7 @@ test("quote removes a legacy row that has no archived message", async () => {
   const stored = await Effect.runPromise(database.all("SELECT id FROM quote_db"));
   database.close();
 
-  expect(fake.requests.some((request) => request.method === "forwardMessage")).toBe(false);
+  expect(fake.requests.some((request) => request.method === "forwardMessage")).toBe(archivedMessageId !== null);
   expect(stored).toHaveLength(0);
   expect(fake.requests.find((request) => request.method === "sendMessage")?.params).toMatchObject({
     text: "Quoted message deleted. Removing the quote.",


### PR DESCRIPTION
## Summary

Remove redundant structure across shared services and feature modules while preserving bot behavior. This reduces production code by 140 net lines.

- Use one message-link formatter and one recurring schedule table.
- Derive settings state and model column names instead of maintaining duplicate mappings.
- Remove unused exports, a pass-through HTTP method, unreachable MIME guessing, and redundant byte-copy setup.
- Simplify quota checks, quote cleanup, citation deduplication, and non-empty search message groups.
- Preserve commands, aliases, database behavior, provider fallbacks, and paid-video failure handling.

## Validation

- `bun run check`: 87 tests passed.
- `bunx knip --no-progress`: no findings.
- `bun run test:e2e:search`: passed on Telegram's Test Server with four provider requests and clean teardown.
- Deliberate message-link and grouping-boundary mutations failed the new regression tests; the correct implementation was restored.
