### PR TITLE
fix(translation): use Google batch endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ SuperSeriousBot has grown with its groups for years. It combines AI, media, sear
 
 Run `/help` to see the commands enabled by the configured API keys.
 
+`/tl` uses Google Translate's batch web endpoint through `google-translate-api-x`, without an API key. Use `/tl Bonjour` for English, `/tl fr - Good morning` for a specific language, or reply to a message with `/tl [language]`. Provider outages and rate limits are reported separately from unknown languages.
+
 ## Run locally
 
 Requirements:

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "cron-parser": "5.10.0",
         "effect": "4.0.0-rc.112",
         "fast-xml-parser": "5.11.1",
+        "google-translate-api-x": "10.7.3",
         "sharp": "0.35.4",
         "telly": "file:vendor/telly-0.0.0.tgz",
       },
@@ -202,6 +203,8 @@
     "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.11.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw=="],
+
+    "google-translate-api-x": ["google-translate-api-x@10.7.3", "", {}, "sha512-UCLhGMyzUiQQJuUjw6KM4scl4WJjMq5kYbq3eqLHB0KB96XBQ+VV7L/NUpJ9eMfVxXswXxA6xWhAX1h1OdDLZg=="],
 
     "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cron-parser": "5.10.0",
     "effect": "4.0.0-rc.112",
     "fast-xml-parser": "5.11.1",
+    "google-translate-api-x": "10.7.3",
     "sharp": "0.35.4",
     "telly": "file:vendor/telly-0.0.0.tgz"
   },

--- a/src/features/information.ts
+++ b/src/features/information.ts
@@ -1,3 +1,4 @@
+import translate, { getCode } from "google-translate-api-x";
 import {
   Effect,
   Schema,
@@ -10,6 +11,7 @@ import {
 } from "../app/command.ts";
 import { rowNumber } from "../app/database.ts";
 import type { AppDependencies } from "../app/dependencies.ts";
+import { HttpError } from "../app/http.ts";
 import { replyBlocks, rich } from "../app/rich.ts";
 import { truncate } from "../app/text.ts";
 
@@ -67,7 +69,8 @@ const AqiResponse = Schema.Struct({
   })),
   status: Schema.String,
 });
-const TranslationResponse = Schema.Array(Schema.Unknown);
+const TranslationResponse = Schema.Struct({ text: Schema.NonEmptyString });
+const translationUnavailable = "Translation service is unavailable. Please try again later.";
 
 function definitionCommand(dependencies: AppDependencies): CommandDefinition {
   const definition: CommandDefinition = {
@@ -207,15 +210,6 @@ function translationText(match: Parameters<CommandDefinition["run"]>[0]) {
   return text.length === 0 ? undefined : { target: match.args[0] ?? "en", text };
 }
 
-function parseTranslation(data: ReadonlyArray<unknown>): string | undefined {
-  const segments = data[0];
-  if (!Array.isArray(segments)) return undefined;
-  const translated = segments.flatMap((segment) =>
-    Array.isArray(segment) && typeof segment[0] === "string" ? [segment[0]] : []
-  ).join("");
-  return translated.length === 0 ? undefined : translated;
-}
-
 function translationCommand(dependencies: AppDependencies): CommandDefinition {
   const definition: CommandDefinition = {
     description: "Translate a message or text to the requested language.",
@@ -224,24 +218,44 @@ function translationCommand(dependencies: AppDependencies): CommandDefinition {
     run: Effect.fn("translate")(function* (match) {
       const input = translationText(match);
       if (input === undefined) return yield* usage(match.message, definition);
-      const url = new URL("https://translate.googleapis.com/translate_a/single");
-      url.search = new URLSearchParams({
-        client: "gtx",
-        dt: "t",
-        q: input.text,
-        sl: "auto",
-        tl: input.target,
-      }).toString();
-      const response = yield* dependencies.http.json(
-        "google-translate",
-        url,
-        TranslationResponse,
-      ).pipe(Effect.catch(() => Effect.succeed(undefined)));
-      const translated = response === undefined ? undefined : parseTranslation(response.data);
-      return yield* answer(
-        match.message,
-        translated ?? `Invalid target language: ${input.target}`,
+      const target = getCode(input.target);
+      if (target === null || target === "auto") {
+        return yield* answer(match.message, `Invalid target language: ${input.target}`);
+      }
+      const translated = yield* Effect.tryPromise({
+        try: (signal) => translate(input.text, {
+          to: target,
+          forceBatch: true,
+          fallbackBatch: false,
+          requestFunction: async (url: string, options: RequestInit) => {
+            const response = await dependencies.http.fetch(url, {
+              ...options,
+              signal: AbortSignal.any([signal, AbortSignal.timeout(60_000)]),
+            });
+            if (!response.ok) throw new HttpError({
+              service: "google-translate",
+              description: response.status === 429
+                ? "Translation is temporarily rate-limited. Please try again later."
+                : translationUnavailable,
+            });
+            return response;
+          },
+        }),
+        catch: (error) => error instanceof HttpError ? error : new HttpError({
+          service: "google-translate",
+          description: translationUnavailable,
+        }),
+      }).pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(TranslationResponse)),
+        Effect.map((response) => response.text),
+        Effect.catch((error) => {
+          const message = error instanceof HttpError ? error.description : translationUnavailable;
+          return Effect.logWarning("Google translation failed", { reason: message }).pipe(
+            Effect.as(message),
+          );
+        }),
       );
+      return yield* answer(match.message, translated);
     }),
     usage: "/tl [language] - [content]",
   };

--- a/tests/information.test.ts
+++ b/tests/information.test.ts
@@ -12,6 +12,16 @@ import {
 
 const presence = () => [FakeBotApiReply.ok(true), FakeBotApiReply.ok(true)] as const;
 
+function translationResponse(...sentences: ReadonlyArray<string>): Response {
+  const result = [
+    null,
+    [[[null, null, null, null, null, sentences.map((text) => [text])]], "fr", null, "en"],
+    "en",
+  ];
+  const payload = JSON.stringify([["wrb.fr", "MkEWBc", JSON.stringify(result), null, null, "0"]]);
+  return new Response(`)]}'\n\n${payload}\n`);
+}
+
 test("define command renders the first dictionary meaning", async () => {
   const send: Fetch = async () => new Response(JSON.stringify([{
     meanings: [{
@@ -92,11 +102,13 @@ test("calculation command explains an unrecognized query", async () => {
 });
 
 test("translate command sends the complete translated text", async () => {
-  const send: Fetch = async () => new Response(JSON.stringify([
-    [["Bonjour ", "Good "], ["matin", "morning"]],
-    null,
-    "en",
-  ]));
+  let requestUrl = "";
+  let requestMethod = "";
+  const send: Fetch = async (input, options) => {
+    requestUrl = String(input);
+    requestMethod = options?.method ?? "GET";
+    return translationResponse("Bonjour.", "Bonne matinée.");
+  };
   const { app, bot, database, fake } = await fixture(send, presence());
 
   try {
@@ -107,7 +119,51 @@ test("translate command sends the complete translated text", async () => {
   }
 
   const reply = fake.requests.find((request) => request.method === "sendMessage");
-  expect(reply?.params).toMatchObject({ text: "Bonjour matin" });
+  expect(reply?.params).toMatchObject({ text: "Bonjour. Bonne matinée." });
+  expect(new URL(requestUrl).pathname).toBe("/_/TranslateWebserverUi/data/batchexecute");
+  expect(requestMethod).toBe("POST");
+});
+
+test("translate command rejects an unknown language before requesting a translation", async () => {
+  let requests = 0;
+  const { app, bot, database, fake } = await fixture(async () => {
+    requests += 1;
+    return translationResponse("Hello");
+  }, presence());
+
+  try {
+    await app.run(bot.handler(commandUpdate("/tl klingon - Hello", 206)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const reply = fake.requests.find((request) => request.method === "sendMessage");
+  expect(reply?.params).toMatchObject({ text: "Invalid target language: klingon" });
+  expect(requests).toBe(0);
+});
+
+test.each([
+  { status: 429, body: "<html>Automated queries blocked</html>", message: "Translation is temporarily rate-limited. Please try again later." },
+  { status: 503, body: "Service unavailable", message: "Translation service is unavailable. Please try again later." },
+  { status: 200, body: "<html>Unexpected response</html>", message: "Translation service is unavailable. Please try again later." },
+])("translate command reports provider failure for $status", async ({ status, body, message }) => {
+  let requests = 0;
+  const { app, bot, database, fake } = await fixture(async () => {
+    requests += 1;
+    return new Response(body, { status });
+  }, presence());
+
+  try {
+    await app.run(bot.handler(commandUpdate("/tl Bonjour", 207)));
+  } finally {
+    await app.close();
+    database.close();
+  }
+
+  const reply = fake.requests.find((request) => request.method === "sendMessage");
+  expect(reply?.params).toMatchObject({ text: message });
+  expect(requests).toBe(1);
 });
 
 test("weather command stores the resolved location and renders air quality", async () => {


### PR DESCRIPTION
Restore `/tl` by using Google Translate's batch web endpoint through `google-translate-api-x` 10.7.3. The former single endpoint returns 429 from production, which the bot incorrectly reported as an invalid language.

Preserve default English, explicit target languages, and reply translation. Reject unknown languages locally, report throttling and service failures accurately, and remove the old response parser. Requests retain cancellation and a timeout, with no retry or fallback to the blocked endpoint.

Validation: `bunx bun@1.4.0 run check` passes all 91 tests. Regression tests failed before the fix and now cover batch translation, invalid languages, 429, 503, and malformed responses. A leased Telegram Test Server run delivered default-English, explicit-French, and reply translations through the live Google batch endpoint; all three requests returned 200. An invalid-language command returned its specific error without another provider request.
