### PR TITLE
fix(search): avoid repeated history scans and index lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ bun run operator search-index --chat-id -1001234567890
 bun run operator search-memory --chat-id -1001234567890
 ```
 
+Before deploying the incremental search indexer to an existing database, run
+`bun run operator migrate-query-schema` with that database's environment.
+This additive migration creates lookup indexes, search progress, and source-change
+triggers. It preserves existing rows and is safe to run again.
+
+Indexing saves progress separately for each chat and embedding configuration.
+Unchanged chats do no indexing work. New messages extend the unfinished windows
+and speaker groups. Older imports, source edits or deletes, and author changes
+request the existing full-history pass. Existing embedding ranges retain their
+current reuse behavior. A failed or superseded pass cannot advance progress.
+
 ## Stack
 
 - [Telly](https://github.com/obviyus/telly) owns Telegram transport, updates, routing, persistence, and jobs.

--- a/src/app/query-schema.ts
+++ b/src/app/query-schema.ts
@@ -1,0 +1,51 @@
+export const querySchema = [
+  `CREATE INDEX IF NOT EXISTS user_stats_username_index ON user_stats (LOWER(username))`,
+  `CREATE INDEX IF NOT EXISTS chat_stats_member_latest_index ON chat_stats (chat_id, user_id, id)`,
+  `CREATE INDEX IF NOT EXISTS chat_search_windows_latest_index ON chat_search_windows (chat_id, end_message_id)`,
+  `CREATE INDEX IF NOT EXISTS chat_search_utterances_progress_index
+    ON chat_search_utterances (chat_id, embedding_model, embedding_dimension, start_message_id, end_message_id)`,
+  `CREATE TABLE IF NOT EXISTS chat_search_progress (
+    chat_id INTEGER NOT NULL,
+    embedding_model TEXT NOT NULL,
+    window_dimension INTEGER NOT NULL,
+    utterance_dimension INTEGER NOT NULL,
+    revision INTEGER NOT NULL DEFAULT 0,
+    indexed_revision INTEGER NOT NULL DEFAULT -1,
+    rebuild INTEGER NOT NULL DEFAULT 1,
+    end_message_id INTEGER,
+    window_tail TEXT NOT NULL DEFAULT '[]',
+    utterance_tail TEXT NOT NULL DEFAULT '[]',
+    PRIMARY KEY (chat_id, embedding_model, window_dimension, utterance_dimension)
+  )`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_source_insert AFTER INSERT ON chat_stats BEGIN
+    UPDATE chat_search_progress SET revision = revision + 1,
+      rebuild = CASE WHEN NEW.message_id <= end_message_id THEN 1 ELSE rebuild END
+    WHERE chat_id = NEW.chat_id;
+  END`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_source_update
+    AFTER UPDATE OF chat_id, user_id, message_id, message_text, create_time ON chat_stats
+    WHEN OLD.chat_id IS NOT NEW.chat_id OR OLD.user_id IS NOT NEW.user_id
+      OR OLD.message_id IS NOT NEW.message_id OR OLD.message_text IS NOT NEW.message_text
+      OR OLD.create_time IS NOT NEW.create_time
+    BEGIN
+      UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+      WHERE chat_id IN (OLD.chat_id, NEW.chat_id);
+    END`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_source_delete AFTER DELETE ON chat_stats BEGIN
+    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1 WHERE chat_id = OLD.chat_id;
+  END`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_author_insert AFTER INSERT ON user_stats BEGIN
+    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+    WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = NEW.user_id);
+  END`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_author_update AFTER UPDATE OF username ON user_stats
+    WHEN OLD.username IS NOT NEW.username
+    BEGIN
+      UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+      WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = NEW.user_id);
+    END`,
+  `CREATE TRIGGER IF NOT EXISTS chat_search_author_delete AFTER DELETE ON user_stats BEGIN
+    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+    WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = OLD.user_id);
+  END`,
+] as const;

--- a/src/app/schema.ts
+++ b/src/app/schema.ts
@@ -1,6 +1,7 @@
 import { Effect } from "telly";
 
 import type { Database } from "./database.ts";
+import { querySchema } from "./query-schema.ts";
 
 const statements = [
   `CREATE TABLE IF NOT EXISTS command_stats (
@@ -352,7 +353,7 @@ const statements = [
 
 export function initializeDatabase(database: Database) {
   return Effect.gen(function* () {
-    yield* Effect.forEach(statements, (statement) => database.execute(statement), {
+    yield* Effect.forEach([...statements, ...querySchema], (statement) => database.execute(statement), {
       concurrency: 1,
       discard: true,
     });

--- a/src/features/search.ts
+++ b/src/features/search.ts
@@ -125,7 +125,15 @@ export function buildUtterances(messages: ReadonlyArray<SourceMessage>): Readonl
   });
 }
 
-function sourceMessages(dependencies: AppDependencies, chatId: number) {
+const SourceTail = Schema.Array(Schema.Struct({
+  author: Schema.String,
+  createTime: Schema.String,
+  messageId: Schema.Int,
+  text: Schema.String,
+  userId: Schema.Int,
+}));
+
+function sourceMessages(dependencies: AppDependencies, chatId: number, after?: number) {
   return dependencies.database.all(
     `SELECT messages.message_id, messages.user_id, messages.create_time,
             COALESCE(users.username, 'user:' || messages.user_id) AS author,
@@ -135,8 +143,9 @@ function sourceMessages(dependencies: AppDependencies, chatId: number) {
      WHERE messages.chat_id = ? AND messages.message_id IS NOT NULL
        AND messages.message_text IS NOT NULL AND messages.message_text != ''
        AND messages.message_text NOT LIKE '/%'
+       ${after === undefined ? "" : "AND messages.message_id > ?"}
      ORDER BY messages.message_id`,
-    [chatId],
+    after === undefined ? [chatId] : [chatId, after],
   ).pipe(Effect.map((rows): ReadonlyArray<SourceMessage> => rows.map((row) => ({
     author: rowString(row, "author").startsWith("user:")
       ? rowString(row, "author")
@@ -150,18 +159,50 @@ function sourceMessages(dependencies: AppDependencies, chatId: number) {
 
 function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
   return Effect.gen(function* () {
-    const messages = yield* sourceMessages(dependencies, chatId);
-    const windows = buildWindows(messages);
-    const utterances = buildUtterances(messages);
-    const indexedWindows = new Set((yield* dependencies.database.all(
+    const profile = [chatId, embeddingModel];
+    const profileWhere = `chat_id = ? AND embedding_model = ?
+      AND window_dimension = 1024 AND utterance_dimension = 256`;
+    yield* dependencies.database.execute(
+      `INSERT INTO chat_search_progress (chat_id, embedding_model, window_dimension, utterance_dimension)
+       VALUES (?, ?, 1024, 256) ON CONFLICT DO NOTHING`,
+      profile,
+    );
+    const progress = (yield* dependencies.database.all(
+      `SELECT revision, indexed_revision, rebuild, end_message_id, window_tail, utterance_tail
+       FROM chat_search_progress WHERE ${profileWhere}`,
+      profile,
+    ))[0]!;
+    const revision = rowNumber(progress, "revision");
+    const indexedRevision = rowNumber(progress, "indexed_revision");
+    if (revision === indexedRevision) return;
+    const rebuild = rowNumber(progress, "rebuild") === 1;
+    const after = rebuild || progress["end_message_id"] === null
+      ? undefined : rowNumber(progress, "end_message_id");
+    const messages = yield* sourceMessages(dependencies, chatId, after);
+    const windowMessages = [
+      ...(rebuild ? [] : Schema.decodeUnknownSync(SourceTail)(JSON.parse(rowString(progress, "window_tail")))),
+      ...messages,
+    ];
+    const utteranceMessages = [
+      ...(rebuild ? [] : Schema.decodeUnknownSync(SourceTail)(JSON.parse(rowString(progress, "utterance_tail")))),
+      ...messages,
+    ];
+    const windows = buildWindows(windowMessages);
+    const utterances = buildUtterances(utteranceMessages);
+    const guard = `EXISTS (SELECT 1 FROM chat_search_progress WHERE ${profileWhere}
+      AND revision = ? AND indexed_revision = ?)`;
+    const guardArgs = [...profile, revision, indexedRevision];
+    const indexedWindows = new Set((windows.length === 0 ? [] : yield* dependencies.database.all(
       `SELECT start_message_id, end_message_id FROM chat_search_windows
-       WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 1024`,
-      [chatId, embeddingModel],
+       WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 1024
+         AND start_message_id >= ?`,
+      [...profile, windows[0]!.startMessageId],
     )).map((row) => `${rowNumber(row, "start_message_id")}:${rowNumber(row, "end_message_id")}`));
-    const indexedUtterances = new Set((yield* dependencies.database.all(
+    const indexedUtterances = new Set((utterances.length === 0 ? [] : yield* dependencies.database.all(
       `SELECT start_message_id, end_message_id FROM chat_search_utterances
-       WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 256`,
-      [chatId, embeddingModel],
+       WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 256
+         AND start_message_id >= ?`,
+      [...profile, utterances[0]!.startMessageId],
     )).map((row) => `${rowNumber(row, "start_message_id")}:${rowNumber(row, "end_message_id")}`));
     for (const batch of chunksOf(windows, 64)) {
       const missing = batch.filter((window) => !indexedWindows.has(`${window.startMessageId}:${window.endMessageId}`));
@@ -172,7 +213,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
           `INSERT OR REPLACE INTO chat_search_windows (
             chat_id, start_message_id, end_message_id, start_time, end_time,
             message_count, message_text, embedding, embedding_model, embedding_dimension
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 1024)`,
+          ) SELECT ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 1024 WHERE ${guard}`,
           [
             chatId,
             window.startMessageId,
@@ -183,13 +224,14 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
             window.text,
             JSON.stringify(embeddings[index]!),
             embeddingModel,
+            ...guardArgs,
           ],
         );
         yield* dependencies.database.execute(
           `DELETE FROM chat_search_windows
            WHERE chat_id = ? AND start_message_id = ? AND end_message_id < ?
-             AND embedding_model = ? AND embedding_dimension = 1024`,
-          [chatId, window.startMessageId, window.endMessageId, embeddingModel],
+             AND embedding_model = ? AND embedding_dimension = 1024 AND ${guard}`,
+          [chatId, window.startMessageId, window.endMessageId, embeddingModel, ...guardArgs],
         );
       }), { concurrency: 1, discard: true });
     }
@@ -201,7 +243,7 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
         `INSERT OR REPLACE INTO chat_search_utterances (
           chat_id, start_message_id, end_message_id, user_id, author, start_time,
           end_time, message_count, message_text, embedding, embedding_model, embedding_dimension
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 256)`,
+        ) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 256 WHERE ${guard}`,
         [
           chatId,
           item.startMessageId,
@@ -214,9 +256,25 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
           item.text,
           JSON.stringify(embeddings[index]!),
           embeddingModel,
+          ...guardArgs,
         ],
       ), { concurrency: 1, discard: true });
     }
+    // Preserve the exact overlap alignment and the final speaker group for the next append.
+    const completedWindows = windows.filter((window) => window.messageCount === 24).length;
+    const finalUtterance = utterances.at(-1);
+    yield* dependencies.database.execute(
+      `UPDATE chat_search_progress SET indexed_revision = ?, rebuild = 0,
+         end_message_id = ?, window_tail = ?, utterance_tail = ?
+       WHERE ${profileWhere} AND revision = ? AND indexed_revision = ?`,
+      [
+        revision,
+        messages.at(-1)?.messageId ?? after ?? null,
+        JSON.stringify(windowMessages.slice(completedWindows * 8)),
+        JSON.stringify(finalUtterance === undefined ? [] : utteranceMessages.slice(-finalUtterance.messageCount)),
+        ...guardArgs,
+      ],
+    );
   });
 }
 

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -82,7 +82,10 @@ function seenCommand(dependencies: AppDependencies): CommandDefinition {
       const row = yield* dependencies.database.one(
         `SELECT us.user_id, us.username, cs.message_id, cs.create_time
          FROM user_stats us
-         JOIN chat_stats cs ON cs.user_id = us.user_id AND cs.chat_id = ?
+         JOIN chat_stats cs ON cs.id = (
+           SELECT id FROM chat_stats WHERE chat_id = ? AND user_id = us.user_id
+           ORDER BY id DESC LIMIT 1
+         )
          WHERE LOWER(us.username) = ?
          ORDER BY cs.id DESC LIMIT 1`,
         [match.message.chat.id, username],

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "./app/config.ts";
 import { Database } from "./app/database.ts";
 import type { AppDependencies } from "./app/dependencies.ts";
 import { Http } from "./app/http.ts";
+import { querySchema } from "./app/query-schema.ts";
 import { initializeDatabase } from "./app/schema.ts";
 import { createSuperSeriousBot } from "./bot.ts";
 
@@ -90,12 +91,17 @@ function chatIds(args: ReadonlyArray<string>): ReadonlyArray<number> | undefined
 
 async function main(): Promise<void> {
   const [operation, ...args] = Bun.argv.slice(2);
-  if (!new Set(["usage", "search-index", "search-memory"]).has(operation ?? "")) {
-    throw new Error("Usage: bun run operator <usage|search-index|search-memory> [options]");
+  if (!new Set(["usage", "search-index", "search-memory", "migrate-query-schema"]).has(operation ?? "")) {
+    throw new Error("Usage: bun run operator <usage|search-index|search-memory|migrate-query-schema> [options]");
   }
   const config = loadConfig();
   const database = Database.open(config);
   try {
+    if (operation === "migrate-query-schema") {
+      for (const statement of querySchema) await Effect.runPromise(database.execute(statement));
+      console.log("Query indexes and search progress schema are ready.");
+      return;
+    }
     await Effect.runPromise(initializeDatabase(database));
     if (operation === "usage") {
       const command = option(args, "--command");

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -4,6 +4,7 @@ import { Effect } from "telly";
 
 import { Database } from "../src/app/database.ts";
 import { initializeDatabase } from "../src/app/schema.ts";
+import { querySchema } from "../src/app/query-schema.ts";
 
 test("database from all 33 Python migrations preserves rows during TypeScript initialization", async () => {
   const client = createClient({ intMode: "number", url: "file::memory:" });
@@ -61,4 +62,25 @@ test("database from all 33 Python migrations preserves rows during TypeScript in
     "attempt_count",
   ]));
   expect(legacyTable?.["name"]).toBe("tv_shows");
+});
+
+test("query migration upgrades an existing database without replacing source or embedding rows", async () => {
+  const client = createClient({ intMode: "number", url: "file::memory:" });
+  const database = new Database(client);
+  try {
+    await client.executeMultiple(await Bun.file(new URL("fixtures/legacy-schema.sql", import.meta.url)).text());
+    await client.execute("INSERT INTO user_stats (user_id, username) VALUES (7, 'Alice')");
+    await client.execute("INSERT INTO chat_stats (chat_id, user_id, message_id, message_text) VALUES (-1007, 7, 20, 'history')");
+    const tables = ["user_stats", "chat_stats", "chat_search_windows", "chat_search_utterances"];
+    const before = await Promise.all(tables.map((table) => client.execute(`SELECT * FROM ${table}`)));
+    for (const statement of querySchema) await Effect.runPromise(database.execute(statement));
+    for (const statement of querySchema) await Effect.runPromise(database.execute(statement));
+    const after = await Promise.all(tables.map((table) => client.execute(`SELECT * FROM ${table}`)));
+    expect(after.map((result) => result.rows)).toEqual(before.map((result) => result.rows));
+    expect((await client.execute("SELECT * FROM chat_search_progress")).rows).toEqual([]);
+    const plan = await client.execute("EXPLAIN QUERY PLAN SELECT user_id FROM user_stats WHERE LOWER(username) = 'alice'");
+    expect(plan.rows.some((row) => String(row["detail"]).includes("SEARCH user_stats USING INDEX"))).toBe(true);
+  } finally {
+    database.close();
+  }
 });

--- a/tests/query-efficiency.test.ts
+++ b/tests/query-efficiency.test.ts
@@ -1,0 +1,320 @@
+import { expect, spyOn, test } from "bun:test";
+import { Effect } from "telly";
+import { FakeBotApiReply } from "telly/testing";
+
+import { type Database } from "../src/app/database.ts";
+import { querySchema } from "../src/app/query-schema.ts";
+import { createSuperSeriousBot } from "../src/bot.ts";
+import { commandUpdate, fixture, openRouterEmbeddings, openRouterText, testConfig } from "./harness.ts";
+
+function observeReads(database: Database) {
+  const execute = database.execute.bind(database);
+  const reads: Array<{ sql: string; rows: number; plan: ReadonlyArray<string> }> = [];
+  const spy = spyOn(database, "execute").mockImplementation((sql, args = []) =>
+    execute(sql, args).pipe(Effect.tap((result) => {
+      if (!sql.trimStart().startsWith("SELECT")) return Effect.void;
+      return execute(`EXPLAIN QUERY PLAN ${sql}`, args).pipe(Effect.map((plan) => {
+        reads.push({ sql, rows: result.rows.length, plan: plan.rows.map((row) => String(row["detail"])) });
+      }));
+    })));
+  return { reads, stop: () => spy.mockRestore() };
+}
+
+function insertMessages(database: Database, start: number, count: number) {
+  return Effect.runPromise(database.batch(Array.from({ length: count }, (_, index) => ({
+    args: [-1007, 2, start + index, new Date(Date.UTC(2026, 0, 1, 0, start + index)).toISOString(), `message ${start + index}`],
+    sql: "INSERT INTO chat_stats (chat_id, user_id, message_id, create_time, message_text) VALUES (?, ?, ?, ?, ?)",
+  }))));
+}
+
+test("indexing reads only new messages and unfinished tails across worker restarts", async () => {
+  let embeddings = 0;
+  const { app, bot, database, dependencies } = await fixture(async (_input, init) => {
+    embeddings += 1;
+    return openRouterEmbeddings(String(init?.body));
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  await insertMessages(database, 1, 2_400);
+  try {
+    await app.run(bot.workers.search.index([-1007]));
+    const initialCalls = embeddings;
+    const observed = observeReads(database);
+    await app.run(createSuperSeriousBot(dependencies).workers.search.index([-1007]));
+    const unchangedRows = observed.reads.reduce((sum, read) => sum + read.rows, 0);
+    expect(embeddings).toBe(initialCalls);
+    expect(unchangedRows).toBeLessThan(10);
+    observed.reads.length = 0;
+    await insertMessages(database, 2_401, 10);
+    await app.run(createSuperSeriousBot(dependencies).workers.search.index([-1007]));
+    const appendRows = observed.reads.reduce((sum, read) => sum + read.rows, 0);
+    expect(appendRows).toBeLessThan(100);
+    expect(observed.reads.filter((read) => read.sql.includes("FROM chat_stats messages"))
+      .flatMap((read) => read.plan).some((detail) => detail.includes("message_id>?"))).toBe(true);
+    console.log({ unchangedRows, appendRows });
+    observed.stop();
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test("seen resolves usernames before looking up each user's latest inserted message", async () => {
+  const { app, bot, database, fake } = await fixture(async () => new Response("{}"), [
+    FakeBotApiReply.ok(true), FakeBotApiReply.ok(true),
+  ]);
+  await Effect.runPromise(database.batch([
+    { sql: "INSERT INTO user_stats (user_id, username) VALUES (2, 'Alice'), (3, 'aLiCe')" },
+    { sql: "INSERT INTO chat_stats (chat_id, user_id, message_id, create_time) VALUES (-1007, 2, 9000, '2026-01-01'), (-1007, 3, 8000, '2026-01-02'), (-1008, 2, 9999, '2026-01-03'), (-1007, 2, 7, '2026-01-04')" },
+  ]));
+  const observed = observeReads(database);
+  try {
+    await app.run(bot.handler(commandUpdate("/seen @ALICE", 10001)));
+    expect(JSON.stringify(fake.requests)).toContain("https://t.me/c/7/7");
+    const lookup = observed.reads.find((read) => read.sql.includes("LOWER(us.username)"));
+    expect(lookup).toBeDefined();
+    expect(lookup?.plan.some((detail) => detail.includes("SEARCH us USING INDEX"))).toBe(true);
+    expect(lookup?.plan.some((detail) => detail.includes("chat_id=? AND user_id=?"))).toBe(true);
+    expect(lookup?.plan.some((detail) => detail.startsWith("SEARCH cs") && detail.endsWith("(chat_id=?)"))).toBe(false);
+  } finally {
+    observed.stop();
+    await app.close();
+    database.close();
+  }
+});
+
+test("passive username resolution uses an index", async () => {
+  const { app, bot, database } = await fixture(async () => openRouterText('{"items":[]}'), [], testConfig({ openrouterApiKey: "test" }));
+  await Effect.runPromise(database.execute("INSERT INTO user_stats (user_id, username) VALUES (2, 'Alice')"));
+  const observed = observeReads(database);
+  try {
+    const update = commandUpdate("@ALICE hi", 10002);
+    if (update.message === undefined) throw new Error("Expected message");
+    await app.run(bot.handler({ ...update, message: { ...update.message, entities: [{ type: "mention", offset: 0, length: 6 }] } }));
+    const username = observed.reads.find((read) => read.sql.includes("LOWER(username)"));
+    expect(username?.plan.some((detail) => detail.includes("SEARCH user_stats USING INDEX"))).toBe(true);
+  } finally {
+    observed.stop();
+    await app.close();
+    database.close();
+  }
+});
+
+test("recent memory windows use an ordered index", async () => {
+  const { app, bot, database } = await fixture(async () => openRouterText('{"items":[]}'), [], testConfig({ openrouterApiKey: "test" }));
+  const observed = observeReads(database);
+  try {
+    await app.run(bot.workers.search.memory([-1007]));
+    const recent = observed.reads.find((read) => read.sql.includes("FROM chat_search_windows"));
+    expect(recent).toBeDefined();
+    expect(recent?.plan.some((detail) => detail.includes("TEMP B-TREE"))).toBe(false);
+  } finally {
+    observed.stop();
+    await app.close();
+    database.close();
+  }
+});
+
+async function searchRows(database: Database) {
+  return {
+    windows: await Effect.runPromise(database.all("SELECT start_message_id, end_message_id, message_text FROM chat_search_windows ORDER BY start_message_id, end_message_id")),
+    utterances: await Effect.runPromise(database.all("SELECT start_message_id, end_message_id, message_text FROM chat_search_utterances ORDER BY start_message_id")),
+  };
+}
+
+test("an older worker cannot overwrite a newer completed index", async () => {
+  const entered = Promise.withResolvers<void>();
+  const resume = Promise.withResolvers<void>();
+  let block = true;
+  const { app, bot, database, dependencies } = await fixture(async (_input, init) => {
+    if (block) {
+      block = false;
+      entered.resolve();
+      await resume.promise;
+    }
+    return openRouterEmbeddings(String(init?.body));
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  await insertMessages(database, 1, 30);
+  const older = app.run(bot.workers.search.index([-1007]));
+  try {
+    await entered.promise;
+    await insertMessages(database, 31, 10);
+    await app.run(createSuperSeriousBot(dependencies).workers.search.index([-1007]));
+    const completed = await searchRows(database);
+    resume.resolve();
+    await older;
+    expect(await searchRows(database)).toEqual(completed);
+  } finally {
+    resume.resolve();
+    await older;
+    await app.close();
+    database.close();
+  }
+});
+
+test("incremental indexing retains full-history behavior through imports, edits, deletes, and author changes", async () => {
+  const send = async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => openRouterEmbeddings(String(init?.body));
+  const incremental = await fixture(send, [], testConfig({ openrouterApiKey: "test" }));
+  const full = await fixture(send, [], testConfig({ openrouterApiKey: "test" }));
+  const both = [incremental, full];
+  const compare = async () => {
+    await Effect.runPromise(full.database.execute("DELETE FROM chat_search_progress"));
+    for (const setup of both) await setup.app.run(setup.bot.workers.search.index([-1007]));
+    expect(await searchRows(incremental.database)).toEqual(await searchRows(full.database));
+  };
+  try {
+    await compare();
+    for (const setup of both) await insertMessages(setup.database, 10, 29);
+    await compare();
+    for (const count of [1, 2, 8, 12, 24, 65]) {
+      const row = await Effect.runPromise(full.database.one("SELECT MAX(message_id) AS last FROM chat_stats"));
+      for (const setup of both) await insertMessages(setup.database, Number(row?.["last"]) + 1, count);
+      await compare();
+    }
+    for (const setup of both) await insertMessages(setup.database, 1, 9);
+    await compare();
+    for (const sql of [
+      "UPDATE chat_stats SET message_text = 'edited', create_time = '2026-01-01T10:00:00Z' WHERE message_id = 3",
+      "UPDATE chat_stats SET user_id = 3 WHERE message_id IN (25, 26, 27)",
+      "DELETE FROM chat_stats WHERE message_id IN (2, 5, 28, 33)",
+      "INSERT INTO user_stats (user_id, username) VALUES (2, 'Alice')",
+      "UPDATE user_stats SET username = 'Bob' WHERE user_id = 2",
+      "DELETE FROM user_stats WHERE user_id = 2",
+    ]) {
+      for (const setup of both) await Effect.runPromise(setup.database.execute(sql));
+      await compare();
+    }
+    for (const setup of both) await insertMessages(setup.database, 200, 40);
+    await compare();
+    for (const setup of both) await Effect.runPromise(setup.database.execute("DELETE FROM chat_stats"));
+    await compare();
+    for (const setup of both) await insertMessages(setup.database, 300, 9);
+    await compare();
+  } finally {
+    for (const setup of both) {
+      await setup.app.close();
+      setup.database.close();
+    }
+  }
+});
+
+test.each(["append", "older import"])("a %s during embedding remains pending for the next worker", async (change) => {
+  const entered = Promise.withResolvers<void>();
+  const resume = Promise.withResolvers<void>();
+  let block = false;
+  const { app, bot, database } = await fixture(async (_input, init) => {
+    if (block) {
+      block = false;
+      entered.resolve();
+      await resume.promise;
+    }
+    return openRouterEmbeddings(String(init?.body));
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await insertMessages(database, 10, 30);
+    await app.run(bot.workers.search.index([-1007]));
+    await insertMessages(database, 40, 10);
+    block = true;
+    const indexing = app.run(bot.workers.search.index([-1007]));
+    await entered.promise;
+    await insertMessages(database, change === "append" ? 50 : 1, 9);
+    resume.resolve();
+    await indexing;
+    const pending = await Effect.runPromise(database.one("SELECT revision, indexed_revision FROM chat_search_progress"));
+    expect(pending?.["revision"]).not.toBe(pending?.["indexed_revision"]);
+    await app.run(bot.workers.search.index([-1007]));
+    const indexed = await Effect.runPromise(database.one("SELECT revision, indexed_revision FROM chat_search_progress"));
+    expect(indexed?.["revision"]).toBe(indexed?.["indexed_revision"]);
+    const rows = await searchRows(database);
+    expect(rows.windows.some((row) => String(row["message_text"]).includes(change === "append" ? "message 58" : "message 1\n"))).toBe(true);
+  } finally {
+    resume.resolve();
+    await app.close();
+    database.close();
+  }
+});
+
+test("progress adds one write per tracked source insert and ignores unchanged usernames", async () => {
+  const { app, bot, database } = await fixture(async (_input, init) => openRouterEmbeddings(String(init?.body)), [], testConfig({ openrouterApiKey: "test" }));
+  const control = await fixture(async (_input, init) => openRouterEmbeddings(String(init?.body)), [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await Effect.runPromise(database.execute("INSERT INTO user_stats (user_id, username) VALUES (2, 'Alice')"));
+    await insertMessages(database, 1, 30);
+    await app.run(bot.workers.search.index([-1007]));
+    await Effect.runPromise(control.database.execute("INSERT INTO user_stats (user_id, username) VALUES (2, 'Alice')"));
+    await insertMessages(control.database, 1, 30);
+    await control.app.run(control.bot.workers.search.index([-1007]));
+    await Effect.runPromise(control.database.execute("DELETE FROM chat_search_progress"));
+    const total = async () => Number((await Effect.runPromise(database.one("SELECT total_changes() AS count")))?.["count"]);
+    const controlTotal = async () => Number((await Effect.runPromise(control.database.one("SELECT total_changes() AS count")))?.["count"]);
+    const idleBefore = await total();
+    await app.run(bot.workers.search.index([-1007]));
+    expect(await total() - idleBefore).toBe(0);
+    const before = await total();
+    await insertMessages(database, 31, 1);
+    const withProgress = await total() - before;
+    const revision = await Effect.runPromise(database.one("SELECT revision FROM chat_search_progress"));
+    await Effect.runPromise(database.execute("UPDATE user_stats SET username = 'Alice', last_seen = '2026-09-12' WHERE user_id = 2"));
+    expect(await Effect.runPromise(database.one("SELECT revision FROM chat_search_progress"))).toEqual(revision);
+    await Effect.runPromise(database.execute("UPDATE user_stats SET username = 'Renamed' WHERE user_id = 2"));
+    const renamed = await Effect.runPromise(database.one("SELECT revision, rebuild FROM chat_search_progress"));
+    expect(renamed?.["revision"]).toBe(Number(revision?.["revision"]) + 1);
+    expect(renamed?.["rebuild"]).toBe(1);
+    const baselineBefore = await controlTotal();
+    await insertMessages(control.database, 31, 1);
+    const withoutProgress = await controlTotal() - baselineBefore;
+    expect(withProgress - withoutProgress).toBe(1);
+    console.log({ insertWritesWithProgress: withProgress, insertWritesWithoutProgress: withoutProgress });
+  } finally {
+    await app.close();
+    database.close();
+    await control.app.close();
+    control.database.close();
+  }
+});
+
+test("a failed embedding pass does not advance progress and resumes through a fresh worker", async () => {
+  let fail = true;
+  const { app, bot, database, dependencies } = await fixture(async (_input, init) => {
+    const body = String(init?.body);
+    if (fail && JSON.parse(body).dimensions === 256) {
+      fail = false;
+      return new Response('{"error":{"message":"synthetic embedding failure"}}', { status: 400 });
+    }
+    return openRouterEmbeddings(body);
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await insertMessages(database, 1, 30);
+    await expect(app.run(bot.workers.search.index([-1007]))).rejects.toBeDefined();
+    const failed = await Effect.runPromise(database.one("SELECT indexed_revision FROM chat_search_progress"));
+    expect(failed?.["indexed_revision"]).toBe(-1);
+    await app.run(createSuperSeriousBot(dependencies).workers.search.index([-1007]));
+    const complete = await Effect.runPromise(database.one("SELECT revision, indexed_revision FROM chat_search_progress"));
+    expect(complete?.["revision"]).toBe(complete?.["indexed_revision"]);
+    expect((await searchRows(database)).utterances.at(-1)?.["end_message_id"]).toBe(30);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test("additive migration preserves existing embedding configurations and checkpoints", async () => {
+  const { app, bot, database } = await fixture(async (_input, init) => openRouterEmbeddings(String(init?.body)), [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await insertMessages(database, 1, 29);
+    await app.run(bot.workers.search.index([-1007]));
+    await Effect.runPromise(database.execute("UPDATE chat_search_windows SET embedding_model = 'previous-model'"));
+    await Effect.runPromise(database.execute("UPDATE chat_search_utterances SET embedding_model = 'previous-model'"));
+    const legacy = await searchRows(database);
+    await Effect.runPromise(database.execute("DELETE FROM chat_search_progress"));
+    for (const sql of querySchema) await Effect.runPromise(database.execute(sql));
+    expect(await searchRows(database)).toEqual(legacy);
+    await app.run(bot.workers.search.index([-1007]));
+    const current = await Effect.runPromise(database.all("SELECT embedding_model, COUNT(*) AS count FROM chat_search_windows GROUP BY embedding_model"));
+    expect(current.map((row) => row["count"])).toEqual([4, 4]);
+    const progress = await Effect.runPromise(database.all("SELECT * FROM chat_search_progress"));
+    for (const sql of querySchema) await Effect.runPromise(database.execute(sql));
+    expect(await Effect.runPromise(database.all("SELECT * FROM chat_search_progress"))).toEqual(progress);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});


### PR DESCRIPTION
Search indexing reloads every chat message and embedding range on each scheduled run. It now reads new messages and saved unfinished groups, while source changes request a full pass. Revision checks prevent an older worker from overwriting newer work. Existing embedding ranges and imported history keep their current behavior.

Username lookups now use an expression index. `/seen` finds each matching user's newest inserted message before choosing the latest result. Recent memory windows use an index that supplies the requested order.

Validation:
- Five regression tests failed on the unchanged implementation before the fix.
- `bun run check`: 103 tests pass.
- A 2,400-message workload returns 1 row instead of 2,900 on an unchanged run; appending 10 messages returns 14 rows.
- Tests cover older imports, edits, deletes, author changes, partial tails, restarts, failed embedding requests, and concurrent workers.
- Progress adds one row update per source insert per active embedding configuration; unchanged indexing adds no writes.

Deployment: run `bun run operator migrate-query-schema` against the existing database before deploying. The migration adds indexes, progress storage, and triggers without removing existing rows. Startup uses the same schema definitions.
