### PR TITLE
fix(search): save captured prefixes during sustained arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,19 @@ bun run operator search-memory --chat-id -1001234567890
 
 Before deploying the incremental search indexer to an existing database, run
 `bun run operator migrate-query-schema` with that database's environment.
-This additive migration creates lookup indexes, search progress, and source-change
-triggers. It preserves existing rows and is safe to run again.
+The migration adds the generation column to existing search progress and replaces
+the source-change triggers in one transaction. It preserves existing rows and the
+previous indexer's append notifications, and is safe to run again. Run it separately
+before replacing the running bot; startup does not upgrade existing progress.
 
 Indexing saves progress separately for each chat and embedding configuration.
 Unchanged chats do no indexing work. New messages extend the unfinished windows
 and speaker groups. Older imports, source edits or deletes, and author changes
 request the existing full-history pass. Existing embedding ranges retain their
-current reuse behavior. A failed or superseded pass cannot advance progress.
+current reuse behavior. Each pass claims a generation and captures a fixed message
+boundary. Later appends remain pending without invalidating that prefix. Backfills,
+edits, deletes, author changes, and newer workers invalidate the claim. A failed or
+superseded pass cannot advance progress.
 
 ## Stack
 

--- a/src/app/query-schema.ts
+++ b/src/app/query-schema.ts
@@ -1,3 +1,7 @@
+import { Effect } from "telly";
+
+import type { Database } from "./database.ts";
+
 export const querySchema = [
   `CREATE INDEX IF NOT EXISTS user_stats_username_index ON user_stats (LOWER(username))`,
   `CREATE INDEX IF NOT EXISTS chat_stats_member_latest_index ON chat_stats (chat_id, user_id, id)`,
@@ -11,6 +15,7 @@ export const querySchema = [
     utterance_dimension INTEGER NOT NULL,
     revision INTEGER NOT NULL DEFAULT 0,
     indexed_revision INTEGER NOT NULL DEFAULT -1,
+    generation INTEGER NOT NULL DEFAULT 0,
     rebuild INTEGER NOT NULL DEFAULT 1,
     end_message_id INTEGER,
     window_tail TEXT NOT NULL DEFAULT '[]',
@@ -19,7 +24,16 @@ export const querySchema = [
   )`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_source_insert AFTER INSERT ON chat_stats BEGIN
     UPDATE chat_search_progress SET revision = revision + 1,
-      rebuild = CASE WHEN NEW.message_id <= end_message_id THEN 1 ELSE rebuild END
+      generation = generation + CASE WHEN NEW.message_id <= (
+        SELECT message_id FROM chat_stats
+        WHERE chat_id = NEW.chat_id AND id != NEW.id AND message_id IS NOT NULL
+        ORDER BY message_id DESC LIMIT 1
+      ) THEN 1 ELSE 0 END,
+      rebuild = CASE WHEN NEW.message_id <= (
+        SELECT message_id FROM chat_stats
+        WHERE chat_id = NEW.chat_id AND id != NEW.id AND message_id IS NOT NULL
+        ORDER BY message_id DESC LIMIT 1
+      ) THEN 1 ELSE rebuild END
     WHERE chat_id = NEW.chat_id;
   END`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_source_update
@@ -28,24 +42,36 @@ export const querySchema = [
       OR OLD.message_id IS NOT NEW.message_id OR OLD.message_text IS NOT NEW.message_text
       OR OLD.create_time IS NOT NEW.create_time
     BEGIN
-      UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+      UPDATE chat_search_progress SET revision = revision + 1, generation = generation + 1, rebuild = 1
       WHERE chat_id IN (OLD.chat_id, NEW.chat_id);
     END`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_source_delete AFTER DELETE ON chat_stats BEGIN
-    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1 WHERE chat_id = OLD.chat_id;
+    UPDATE chat_search_progress SET revision = revision + 1, generation = generation + 1, rebuild = 1 WHERE chat_id = OLD.chat_id;
   END`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_author_insert AFTER INSERT ON user_stats BEGIN
-    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+    UPDATE chat_search_progress SET revision = revision + 1, generation = generation + 1, rebuild = 1
     WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = NEW.user_id);
   END`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_author_update AFTER UPDATE OF username ON user_stats
     WHEN OLD.username IS NOT NEW.username
     BEGIN
-      UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+      UPDATE chat_search_progress SET revision = revision + 1, generation = generation + 1, rebuild = 1
       WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = NEW.user_id);
     END`,
   `CREATE TRIGGER IF NOT EXISTS chat_search_author_delete AFTER DELETE ON user_stats BEGIN
-    UPDATE chat_search_progress SET revision = revision + 1, rebuild = 1
+    UPDATE chat_search_progress SET revision = revision + 1, generation = generation + 1, rebuild = 1
     WHERE EXISTS (SELECT 1 FROM chat_stats WHERE chat_id = chat_search_progress.chat_id AND user_id = OLD.user_id);
   END`,
 ] as const;
+
+export const migrateQuerySchema = Effect.fn("migrateQuerySchema")(function* (database: Database) {
+  const columns = yield* database.all("PRAGMA table_info(chat_search_progress)");
+  yield* database.batch([
+    ...(columns.length > 0 && !columns.some((column) => column["name"] === "generation")
+      ? [{ sql: "ALTER TABLE chat_search_progress ADD COLUMN generation INTEGER NOT NULL DEFAULT 0" }]
+      : []),
+    ...["source_insert", "source_update", "source_delete", "author_insert", "author_update", "author_delete"]
+      .map((name) => ({ sql: `DROP TRIGGER IF EXISTS chat_search_${name}` })),
+    ...querySchema.map((sql) => ({ sql })),
+  ]);
+});

--- a/src/features/search.ts
+++ b/src/features/search.ts
@@ -133,7 +133,7 @@ const SourceTail = Schema.Array(Schema.Struct({
   userId: Schema.Int,
 }));
 
-function sourceMessages(dependencies: AppDependencies, chatId: number, after?: number) {
+function sourceMessages(dependencies: AppDependencies, chatId: number, through: number | null, after?: number) {
   return dependencies.database.all(
     `SELECT messages.message_id, messages.user_id, messages.create_time,
             COALESCE(users.username, 'user:' || messages.user_id) AS author,
@@ -143,9 +143,10 @@ function sourceMessages(dependencies: AppDependencies, chatId: number, after?: n
      WHERE messages.chat_id = ? AND messages.message_id IS NOT NULL
        AND messages.message_text IS NOT NULL AND messages.message_text != ''
        AND messages.message_text NOT LIKE '/%'
+       AND messages.message_id <= ?
        ${after === undefined ? "" : "AND messages.message_id > ?"}
      ORDER BY messages.message_id`,
-    after === undefined ? [chatId] : [chatId, after],
+    after === undefined ? [chatId, through] : [chatId, through, after],
   ).pipe(Effect.map((rows): ReadonlyArray<SourceMessage> => rows.map((row) => ({
     author: rowString(row, "author").startsWith("user:")
       ? rowString(row, "author")
@@ -167,18 +168,21 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
        VALUES (?, ?, 1024, 256) ON CONFLICT DO NOTHING`,
       profile,
     );
-    const progress = (yield* dependencies.database.all(
-      `SELECT revision, indexed_revision, rebuild, end_message_id, window_tail, utterance_tail
-       FROM chat_search_progress WHERE ${profileWhere}`,
+    const progress = yield* dependencies.database.one(
+      `UPDATE chat_search_progress SET generation = generation + 1
+       WHERE ${profileWhere} AND revision != indexed_revision
+       RETURNING revision, generation, rebuild, end_message_id, window_tail, utterance_tail,
+         (SELECT MAX(message_id) FROM chat_stats WHERE chat_id = chat_search_progress.chat_id) AS source_end_message_id`,
       profile,
-    ))[0]!;
+    );
+    if (progress === undefined) return;
     const revision = rowNumber(progress, "revision");
-    const indexedRevision = rowNumber(progress, "indexed_revision");
-    if (revision === indexedRevision) return;
+    const through = progress["source_end_message_id"] === null ? null : rowNumber(progress, "source_end_message_id");
+    const generation = rowNumber(progress, "generation");
     const rebuild = rowNumber(progress, "rebuild") === 1;
     const after = rebuild || progress["end_message_id"] === null
       ? undefined : rowNumber(progress, "end_message_id");
-    const messages = yield* sourceMessages(dependencies, chatId, after);
+    const messages = yield* sourceMessages(dependencies, chatId, through, after);
     const windowMessages = [
       ...(rebuild ? [] : Schema.decodeUnknownSync(SourceTail)(JSON.parse(rowString(progress, "window_tail")))),
       ...messages,
@@ -190,8 +194,8 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
     const windows = buildWindows(windowMessages);
     const utterances = buildUtterances(utteranceMessages);
     const guard = `EXISTS (SELECT 1 FROM chat_search_progress WHERE ${profileWhere}
-      AND revision = ? AND indexed_revision = ?)`;
-    const guardArgs = [...profile, revision, indexedRevision];
+      AND generation = ?)`;
+    const guardArgs = [...profile, generation];
     const indexedWindows = new Set((windows.length === 0 ? [] : yield* dependencies.database.all(
       `SELECT start_message_id, end_message_id FROM chat_search_windows
        WHERE chat_id = ? AND embedding_model = ? AND embedding_dimension = 1024
@@ -208,8 +212,8 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
       const missing = batch.filter((window) => !indexedWindows.has(`${window.startMessageId}:${window.endMessageId}`));
       if (missing.length === 0) continue;
       const embeddings = yield* ai.embeddings(missing.map((window) => window.text), 1_024);
-      yield* Effect.forEach(missing, (window, index) => Effect.gen(function* () {
-        yield* dependencies.database.execute(
+      for (const [index, window] of missing.entries()) {
+        const inserted = yield* dependencies.database.execute(
           `INSERT OR REPLACE INTO chat_search_windows (
             chat_id, start_message_id, end_message_id, start_time, end_time,
             message_count, message_text, embedding, embedding_model, embedding_dimension
@@ -227,38 +231,42 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
             ...guardArgs,
           ],
         );
+        if (inserted.rowsAffected === 0) return;
         yield* dependencies.database.execute(
           `DELETE FROM chat_search_windows
            WHERE chat_id = ? AND start_message_id = ? AND end_message_id < ?
              AND embedding_model = ? AND embedding_dimension = 1024 AND ${guard}`,
           [chatId, window.startMessageId, window.endMessageId, embeddingModel, ...guardArgs],
         );
-      }), { concurrency: 1, discard: true });
+      }
     }
     for (const batch of chunksOf(utterances, 64)) {
       const missing = batch.filter((utterance) => !indexedUtterances.has(`${utterance.startMessageId}:${utterance.endMessageId}`));
       if (missing.length === 0) continue;
       const embeddings = yield* ai.embeddings(missing.map((item) => item.text), 256);
-      yield* Effect.forEach(missing, (item, index) => dependencies.database.execute(
-        `INSERT OR REPLACE INTO chat_search_utterances (
-          chat_id, start_message_id, end_message_id, user_id, author, start_time,
-          end_time, message_count, message_text, embedding, embedding_model, embedding_dimension
-        ) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 256 WHERE ${guard}`,
-        [
-          chatId,
-          item.startMessageId,
-          item.endMessageId,
-          item.userId,
-          item.author,
-          item.startTime,
-          item.endTime,
-          item.messageCount,
-          item.text,
-          JSON.stringify(embeddings[index]!),
-          embeddingModel,
-          ...guardArgs,
-        ],
-      ), { concurrency: 1, discard: true });
+      for (const [index, item] of missing.entries()) {
+        const inserted = yield* dependencies.database.execute(
+          `INSERT OR REPLACE INTO chat_search_utterances (
+            chat_id, start_message_id, end_message_id, user_id, author, start_time,
+            end_time, message_count, message_text, embedding, embedding_model, embedding_dimension
+          ) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, 256 WHERE ${guard}`,
+          [
+            chatId,
+            item.startMessageId,
+            item.endMessageId,
+            item.userId,
+            item.author,
+            item.startTime,
+            item.endTime,
+            item.messageCount,
+            item.text,
+            JSON.stringify(embeddings[index]!),
+            embeddingModel,
+            ...guardArgs,
+          ],
+        );
+        if (inserted.rowsAffected === 0) return;
+      }
     }
     // Preserve the exact overlap alignment and the final speaker group for the next append.
     const completedWindows = windows.filter((window) => window.messageCount === 24).length;
@@ -266,10 +274,10 @@ function indexChat(dependencies: AppDependencies, ai: Ai, chatId: number) {
     yield* dependencies.database.execute(
       `UPDATE chat_search_progress SET indexed_revision = ?, rebuild = 0,
          end_message_id = ?, window_tail = ?, utterance_tail = ?
-       WHERE ${profileWhere} AND revision = ? AND indexed_revision = ?`,
+       WHERE ${profileWhere} AND generation = ?`,
       [
         revision,
-        messages.at(-1)?.messageId ?? after ?? null,
+        through,
         JSON.stringify(windowMessages.slice(completedWindows * 8)),
         JSON.stringify(finalUtterance === undefined ? [] : utteranceMessages.slice(-finalUtterance.messageCount)),
         ...guardArgs,

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "./app/config.ts";
 import { Database } from "./app/database.ts";
 import type { AppDependencies } from "./app/dependencies.ts";
 import { Http } from "./app/http.ts";
-import { querySchema } from "./app/query-schema.ts";
+import { migrateQuerySchema } from "./app/query-schema.ts";
 import { initializeDatabase } from "./app/schema.ts";
 import { createSuperSeriousBot } from "./bot.ts";
 
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
   const database = Database.open(config);
   try {
     if (operation === "migrate-query-schema") {
-      for (const statement of querySchema) await Effect.runPromise(database.execute(statement));
+      await Effect.runPromise(migrateQuerySchema(database));
       console.log("Query indexes and search progress schema are ready.");
       return;
     }

--- a/tests/query-efficiency.test.ts
+++ b/tests/query-efficiency.test.ts
@@ -3,7 +3,8 @@ import { Effect } from "telly";
 import { FakeBotApiReply } from "telly/testing";
 
 import { type Database } from "../src/app/database.ts";
-import { querySchema } from "../src/app/query-schema.ts";
+import { migrateQuerySchema, querySchema } from "../src/app/query-schema.ts";
+import { initializeDatabase } from "../src/app/schema.ts";
 import { createSuperSeriousBot } from "../src/bot.ts";
 import { commandUpdate, fixture, openRouterEmbeddings, openRouterText, testConfig } from "./harness.ts";
 
@@ -313,6 +314,168 @@ test("additive migration preserves existing embedding configurations and checkpo
     const progress = await Effect.runPromise(database.all("SELECT * FROM chat_search_progress"));
     for (const sql of querySchema) await Effect.runPromise(database.execute(sql));
     expect(await Effect.runPromise(database.all("SELECT * FROM chat_search_progress"))).toEqual(progress);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test.each([
+  { warm: false, dimension: 1_024 },
+  { warm: true, dimension: 1_024 },
+  { warm: false, dimension: 256 },
+  { warm: true, dimension: 256 },
+])("indexing saves each captured prefix under sustained arrivals: %j", async ({ warm, dimension }) => {
+  let armed = false;
+  let maximum = 2_400;
+  let calls = 0;
+  let append: (count: number) => Promise<unknown>;
+  const { app, bot, database } = await fixture(async (_input, init) => {
+    calls += 1;
+    const body = String(init?.body);
+    if (armed && JSON.parse(body).dimensions === dimension) {
+      armed = false;
+      await append(1);
+    }
+    return openRouterEmbeddings(body);
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  append = async (count) => {
+    const result = await insertMessages(database, maximum + 1, count);
+    maximum += count;
+    return result;
+  };
+  const rounds: Array<{ sourceEnd: number; indexedEnd: unknown; windowsEnd: unknown; utterancesEnd: unknown; sourceRows: number; calls: number }> = [];
+  try {
+    await insertMessages(database, 1, maximum);
+    if (warm) await app.run(bot.workers.search.index([-1007]));
+    const observed = observeReads(database);
+    for (let round = 0; round < 6; round++) {
+      if (warm) await append(10);
+      const sourceEnd = maximum;
+      const previousCalls = calls;
+      observed.reads.length = 0;
+      armed = true;
+      await app.run(bot.workers.search.index([-1007]));
+      expect(armed).toBe(false);
+      const progress = await Effect.runPromise(database.one("SELECT end_message_id FROM chat_search_progress"));
+      const windows = await Effect.runPromise(database.one("SELECT MAX(end_message_id) AS last FROM chat_search_windows"));
+      const utterances = await Effect.runPromise(database.one("SELECT MAX(end_message_id) AS last FROM chat_search_utterances"));
+      rounds.push({ sourceEnd, indexedEnd: progress?.["end_message_id"], windowsEnd: windows?.["last"], utterancesEnd: utterances?.["last"],
+        sourceRows: observed.reads.filter((read) => read.sql.includes("FROM chat_stats messages")).reduce((sum, read) => sum + read.rows, 0), calls: calls - previousCalls });
+    }
+    observed.stop();
+    console.log({ warm, dimension, rounds });
+    expect(rounds.map((round) => round.indexedEnd)).toEqual(rounds.map((round) => round.sourceEnd));
+    expect(rounds.map((round) => round.windowsEnd)).toEqual(rounds.map((round) => round.sourceEnd));
+    expect(rounds.map((round) => round.utterancesEnd)).toEqual(rounds.map((round) => round.sourceEnd));
+    expect(rounds.slice(1).every((round) => round.sourceRows <= 11)).toBe(true);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test.each(["backfill", "edit", "delete", "rename"])("a %s inside the captured suffix invalidates it before publication", async (change) => {
+  let armed = false;
+  let calls = 0;
+  const { app, bot, database } = await fixture(async (_input, init) => {
+    calls += 1;
+    if (armed) {
+      armed = false;
+      if (change === "backfill") await insertMessages(database, 2_450, 1);
+      else await Effect.runPromise(database.execute(change === "edit"
+        ? "UPDATE chat_stats SET message_text = 'edited suffix' WHERE message_id = 2460"
+        : change === "delete" ? "DELETE FROM chat_stats WHERE message_id = 2460"
+        : "UPDATE user_stats SET username = 'renamed' WHERE user_id = 2"));
+    }
+    return openRouterEmbeddings(String(init?.body));
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await Effect.runPromise(database.execute("INSERT INTO user_stats (user_id, username) VALUES (2, 'original')"));
+    await insertMessages(database, 1, 2_400);
+    await app.run(bot.workers.search.index([-1007]));
+    await insertMessages(database, 2_401, 49);
+    await insertMessages(database, 2_451, 50);
+    calls = 0;
+    armed = true;
+    await app.run(bot.workers.search.index([-1007]));
+    expect(calls).toBe(1);
+    const interrupted = await Effect.runPromise(database.one("SELECT revision, indexed_revision, end_message_id FROM chat_search_progress"));
+    expect(interrupted?.["end_message_id"]).toBe(2_400);
+    expect(interrupted?.["revision"]).not.toBe(interrupted?.["indexed_revision"]);
+    await app.run(bot.workers.search.index([-1007]));
+    const complete = await Effect.runPromise(database.one("SELECT revision, indexed_revision, end_message_id FROM chat_search_progress"));
+    expect(complete?.["end_message_id"]).toBe(2_500);
+    expect(complete?.["revision"]).toBe(complete?.["indexed_revision"]);
+    const rows = await searchRows(database);
+    if (change === "backfill") expect(rows.windows.some((row) => String(row["message_text"]).includes("message 2450"))).toBe(true);
+    if (change === "edit") expect(rows.windows.some((row) => String(row["message_text"]).includes("edited suffix"))).toBe(true);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test("excluded command and null-text appends do not stop a captured prefix", async () => {
+  let armed = false;
+  const { app, bot, database } = await fixture(async (_input, init) => {
+    if (armed) {
+      armed = false;
+      await Effect.runPromise(database.execute("INSERT INTO chat_stats (chat_id, user_id, message_id, message_text) VALUES (-1007, 2, 41, '/command'), (-1007, 2, 42, NULL)"));
+    }
+    return openRouterEmbeddings(String(init?.body));
+  }, [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await insertMessages(database, 1, 30);
+    await app.run(bot.workers.search.index([-1007]));
+    await insertMessages(database, 31, 10);
+    armed = true;
+    await app.run(bot.workers.search.index([-1007]));
+    const prefix = await Effect.runPromise(database.one("SELECT end_message_id FROM chat_search_progress"));
+    expect(prefix?.["end_message_id"]).toBe(40);
+    await app.run(bot.workers.search.index([-1007]));
+    const complete = await Effect.runPromise(database.one("SELECT revision, indexed_revision, end_message_id FROM chat_search_progress"));
+    expect(complete?.["end_message_id"]).toBe(42);
+    expect(complete?.["revision"]).toBe(complete?.["indexed_revision"]);
+    expect((await searchRows(database)).utterances.at(-1)?.["end_message_id"]).toBe(40);
+  } finally {
+    await app.close();
+    database.close();
+  }
+});
+
+test("generation migration preserves the old worker's append signal and requires no startup cutover", async () => {
+  const { app, bot, database } = await fixture(async (_input, init) => openRouterEmbeddings(String(init?.body)), [], testConfig({ openrouterApiKey: "test" }));
+  try {
+    await insertMessages(database, 1, 30);
+    await app.run(bot.workers.search.index([-1007]));
+    await Effect.runPromise(database.batch([
+      ...["source_insert", "source_update", "source_delete", "author_insert", "author_update", "author_delete"]
+        .map((name) => ({ sql: `DROP TRIGGER chat_search_${name}` })),
+      { sql: "ALTER TABLE chat_search_progress DROP COLUMN generation" },
+      { sql: `CREATE TRIGGER chat_search_source_insert AFTER INSERT ON chat_stats BEGIN
+          UPDATE chat_search_progress SET revision = revision + 1,
+            rebuild = CASE WHEN NEW.message_id <= end_message_id THEN 1 ELSE rebuild END
+          WHERE chat_id = NEW.chat_id;
+        END` },
+    ]));
+    const before = await searchRows(database);
+    await Effect.runPromise(migrateQuerySchema(database));
+    await Effect.runPromise(migrateQuerySchema(database));
+    expect(await searchRows(database)).toEqual(before);
+    const migrated = await Effect.runPromise(database.one("SELECT revision, indexed_revision, generation FROM chat_search_progress"));
+    await insertMessages(database, 31, 1);
+    const pending = await Effect.runPromise(database.one("SELECT revision, indexed_revision, generation FROM chat_search_progress"));
+    expect(pending?.["revision"]).toBe(Number(migrated?.["revision"]) + 1);
+    expect(pending?.["indexed_revision"]).toBe(migrated?.["indexed_revision"]);
+    expect(pending?.["generation"]).toBe(migrated?.["generation"]);
+    const schemaVersion = await Effect.runPromise(database.one("PRAGMA schema_version"));
+    await Effect.runPromise(initializeDatabase(database));
+    expect(await Effect.runPromise(database.one("PRAGMA schema_version"))).toEqual(schemaVersion);
+    await app.run(bot.workers.search.index([-1007]));
+    const complete = await Effect.runPromise(database.one("SELECT revision, indexed_revision, end_message_id FROM chat_search_progress"));
+    expect(complete?.["end_message_id"]).toBe(31);
+    expect(complete?.["revision"]).toBe(complete?.["indexed_revision"]);
   } finally {
     await app.close();
     database.close();


### PR DESCRIPTION
A message arriving during every embedding pass could invalidate all results and prevent indexing from advancing. Capture a fixed message boundary and claim a generation instead. Later appends stay pending while the captured prefix can finish; backfills, edits, deletes, author changes, and newer workers invalidate the claim.

Publication stops as soon as a write loses its claim. The source revision still records every append, so the existing application keeps its change signal during the separate migration.

Validation:
- Four sustained-arrival regressions failed on the original implementation before source edits.
- Six consecutive busy passes now advance both windows and utterances without a quiet recovery pass. After the initial load, source reads stay at one row per cold pass or eleven rows per warm pass.
- Tests cover backfills inside the captured suffix, edits/deletes/renames, excluded rows, stale workers, failed embeddings, and existing-state migration.
- `bun run check`: 113 tests pass.
- The real migration operator succeeds twice against an existing local database with network calls blocked and preserves progress.

Before deployment, run `bun run operator migrate-query-schema` separately. It adds the generation column and replaces the six triggers atomically while preserving the previous worker's append notifications. Startup does not perform this upgrade.
